### PR TITLE
CPM-1082: Update getIdentifier in AbstractProduct and deprecate setIdentifier

### DIFF
--- a/components/identifier-generator/back/src/Infrastructure/Subscriber/SetIdentifiersSubscriber.php
+++ b/components/identifier-generator/back/src/Infrastructure/Subscriber/SetIdentifiersSubscriber.php
@@ -19,7 +19,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -52,7 +52,7 @@ final class SetIdentifiersSubscriber implements EventSubscriberInterface
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly MatchIdentifierGeneratorHandler $matchIdentifierGeneratorHandler,
         private readonly LoggerInterface $logger,
-        private readonly AttributeRepositoryInterface $attributeRepository,
+        private readonly IdentifiableObjectRepositoryInterface $attributeRepository,
     ) {
     }
 

--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
@@ -14,6 +14,7 @@ services:
       - '@event_dispatcher'
       - '@Akeneo\Pim\Automation\IdentifierGenerator\Application\Match\MatchIdentifierGeneratorHandler'
       - '@monolog.logger'
+      - '@pim_catalog.repository.attribute'
     tags:
       - { name: kernel.event_subscriber }
 

--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
@@ -14,7 +14,7 @@ services:
       - '@event_dispatcher'
       - '@Akeneo\Pim\Automation\IdentifierGenerator\Application\Match\MatchIdentifierGeneratorHandler'
       - '@monolog.logger'
-      - '@pim_catalog.repository.attribute'
+      - '@pim_catalog.repository.cached_attribute'
     tags:
       - { name: kernel.event_subscriber }
 

--- a/components/identifier-generator/back/tests/.php_cd.php
+++ b/components/identifier-generator/back/tests/.php_cd.php
@@ -61,6 +61,7 @@ $rules = [
             'Akeneo\Tool\Component\Batch\Event\StepExecutionEvent',
             'Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface',
             'Akeneo\Tool\Component\Batch\Model\Warning',
+            'Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface',
             'Akeneo\Tool\Component\StorageUtils\StorageEvents',
 
             'Symfony\Component\Config\FileLocator',

--- a/components/identifier-generator/back/tests/Integration/Import/ImportProductsIntegration.php
+++ b/components/identifier-generator/back/tests/Integration/Import/ImportProductsIntegration.php
@@ -56,8 +56,7 @@ class ImportProductsIntegration extends TestCase
         Assert::assertEquals([
             [
                 'reason' => "Your product has been saved but your identifier could not be generated:
-identifier: The identifier attribute must not contain more than 255 characters. The submitted value is too long.
-sku: The identifier attribute must not contain more than 255 characters. The submitted value is too long.",
+sku: The sku attribute must not contain more than 255 characters. The submitted value is too long.",
                 'item' => [
                     'sku' => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 ],

--- a/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
@@ -22,8 +22,9 @@ use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Repository\IdentifierGenera
 use Akeneo\Pim\Automation\IdentifierGenerator\Infrastructure\Subscriber\SetIdentifiersSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
-use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductEntity;
 use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
@@ -48,6 +49,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         MetadataFactoryInterface $metadataFactory,
         EventDispatcherInterface $eventDispatcher,
         LoggerInterface $logger,
+        AttributeRepositoryInterface $attributeRepository,
     ): void {
         $this->beConstructedWith(
             $identifierGeneratorRepository,
@@ -60,7 +62,8 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
             new MatchIdentifierGeneratorHandler(new \ArrayIterator([
                 new MatchEmptyIdentifierHandler(),
             ])),
-            $logger
+            $logger,
+            $attributeRepository
         );
     }
 
@@ -86,11 +89,14 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ProductInterface $product,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $attribute,
     ): void {
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = IdentifierValue::value('sku', true, 'AKN');
         $product->addValue($value)->shouldBeCalled();
-        $product->setIdentifier('AKN')->shouldBeCalled();
+        $attribute->isMainIdentifier()->willReturn(true);
+        $attributeRepository->findOneByIdentifier('sku')->shouldBeCalled()->willReturn($attribute);
         $product->isEnabled()->shouldBeCalled()->willReturn(true);
         $product->getFamily()->shouldBeCalled()->willReturn(null);
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
@@ -104,7 +110,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         $valueMetadata->getPropertyMetadata('data')->shouldBeCalled()->willReturn([$valuePropertyMetadata]);
         $constraint = new Length(null, 10);
         $valuePropertyMetadata->getConstraints()->shouldBeCalled()->willReturn([$constraint]);
-        $validator->validate($value, [$constraint])->shouldBeCalled()->shouldBeCalled()->willReturn(new ConstraintViolationList([]));
+        $validator->validate($value, [$constraint])->shouldBeCalled()->willReturn(new ConstraintViolationList([]));
 
         $logger->notice(
             '[akeneo.pim.identifier_generator] Successfully generated an identifier for the sku attribute',
@@ -124,11 +130,14 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         MetadataFactoryInterface $metadataFactory,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $attribute,
     ): void {
+        $attribute->isMainIdentifier()->shouldBeCalled()->willReturn(true);
+        $attributeRepository->findOneByIdentifier('sku')->shouldBeCalled()->willReturn($attribute);
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = IdentifierValue::value('sku', true, 'AKN');
         $product->addValue($value)->shouldBeCalled();
-        $product->setIdentifier('AKN')->shouldBeCalled();
         $product->isEnabled()->shouldBeCalled()->willReturn(true);
         $product->getFamily()->shouldBeCalled()->willReturn(null);
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
@@ -146,7 +155,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         $validator->validate($value, [])->shouldBeCalled()->willReturn(new ConstraintViolationList([]));
 
         $product->removeValue($value)->shouldBeCalled();
-        $product->setIdentifier(null)->shouldBeCalled();
 
         $eventDispatcher->dispatch(Argument::cetera())->shouldBeCalled();
         $logger->notice(Argument::cetera())->shouldNotBeCalled();
@@ -163,11 +171,14 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         MetadataFactoryInterface $metadataFactory,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
+        AttributeRepositoryInterface $attributeRepository,
+        AttributeInterface $attribute,
     ): void {
+        $attribute->isMainIdentifier()->shouldBeCalled()->willReturn(true);
+        $attributeRepository->findOneByIdentifier('sku')->shouldBeCalled()->willReturn($attribute);
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = IdentifierValue::value('sku', true, 'AKN');
         $product->addValue($value)->shouldBeCalled();
-        $product->setIdentifier('AKN')->shouldBeCalled();
         $product->isEnabled()->shouldBeCalled()->willReturn(true);
         $product->getFamily()->shouldBeCalled()->willReturn(null);
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
@@ -185,7 +196,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ]));
 
         $product->removeValue($value)->shouldBeCalled();
-        $product->setIdentifier(null)->shouldBeCalled();
+        $product->removeValue($value)->shouldBeCalled();
 
         $eventDispatcher->dispatch(Argument::cetera())->shouldBeCalled();
         $logger->notice(Argument::cetera())->shouldNotBeCalled();

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -198,6 +198,12 @@ services:
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
 
+    pim_catalog.validator.constraint_guesser.identifier_format:
+        public: false
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\IdentifierFormatGuesser'
+        tags:
+            - { name: pim_catalog.constraint_guesser.attribute }
+
     pim_catalog.validator.constraint_guesser.length:
         public: false
         class: '%pim_catalog.validator.constraint_guesser.length.class%'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
@@ -118,7 +118,6 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
     ): ValueInterface {
         $newValue = $this->productValueFactory->createByCheckingData($attribute, $channelCode, $localeCode, $data);
         $entityWithValues->addValue($newValue);
-        $this->updateProductIdentiferIfNeeded($attribute, $entityWithValues, $data);
 
         return $newValue;
     }
@@ -135,7 +134,6 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
         if (!$formerValue->isEqual($updatedValue)) {
             $entityWithValues->removeValue($formerValue)->addValue($updatedValue);
         }
-        $this->updateProductIdentiferIfNeeded($attribute, $entityWithValues, $data);
 
         return $updatedValue;
     }
@@ -149,19 +147,7 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
     ): ?ValueInterface {
         $formerValue = $entityWithValues->getValue($attribute->code(), $localeCode, $channelCode);
         $entityWithValues->removeValue($formerValue);
-        $this->updateProductIdentiferIfNeeded($attribute, $entityWithValues, $data);
 
         return null;
-    }
-
-    private function updateProductIdentiferIfNeeded(
-        Attribute $attribute,
-        EntityWithValuesInterface $entityWithValues,
-        $data
-    ): void {
-        // TODO: TIP-722: This is a temporary fix, Product identifier should be used only as a field
-        if (AttributeTypes::IDENTIFIER === $attribute->type() && $entityWithValues instanceof ProductInterface) {
-            $entityWithValues->setIdentifier($data);
-        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
@@ -7,6 +7,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Manager\AttributeValuesResolverInter
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/IdentifierValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/IdentifierValueFactory.php
@@ -29,8 +29,7 @@ final class IdentifierValueFactory implements ValueFactory
             throw new \InvalidArgumentException('An identifier value cannot be scopable nor localizable');
         }
 
-        # TODO: CPM-1068, replace false with $attribute->isMainIdentifier()
-        return IdentifierValue::value($attributeCode, false, $data);
+        return IdentifierValue::value($attributeCode, $attribute->isMainIdentifier(), $data);
     }
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -6,6 +6,7 @@ use Akeneo\Category\Infrastructure\Component\Classification\Model\CategoryInterf
 use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\EntityWithQuantifiedAssociationTrait;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociationCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -244,7 +245,14 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getIdentifier()
     {
-        return $this->identifier;
+        $mainIdentifier = \array_filter($this->values->getValues(), fn ($value) =>
+            $value instanceof IdentifierValue && $value->isMainIdentifier()
+        );
+        if (\count($mainIdentifier) === 0) {
+            return null;
+        }
+
+        return \array_values($mainIdentifier)[0]?->getData() ?? null;
     }
 
     /**
@@ -325,6 +333,7 @@ abstract class AbstractProduct implements ProductInterface
     {
         // TODO CPM: Return the uuid as a fallback when the identifier is null
         $identifier = (string) $this->getIdentifier();
+        // TODO: useless uuid var?
         $uuid = $this->uuid->toString();
 
         if (null === $this->family) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -7,6 +7,7 @@ use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\EntityWithQuantifiedAssociationTrait;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociationCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValueInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -245,14 +246,12 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getIdentifier()
     {
-        $mainIdentifier = \array_filter($this->values->getValues(), fn ($value) =>
-            $value instanceof IdentifierValue && $value->isMainIdentifier()
-        );
-        if (\count($mainIdentifier) === 0) {
-            return null;
-        }
+        /** @var IdentifierValueInterface | null $identifierValue */
+        $identifierValue = $this->values->filter(
+            static fn (ValueInterface $value): bool => $value instanceof IdentifierValueInterface && $value->isMainIdentifier()
+        )->first() ?: null;
 
-        return \array_values($mainIdentifier)[0]?->getData() ?? null;
+        return $identifierValue?->getData();
     }
 
     /**
@@ -331,10 +330,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getLabel($locale = null, $scope = null)
     {
-        // TODO CPM: Return the uuid as a fallback when the identifier is null
         $identifier = (string) $this->getIdentifier();
-        // TODO: useless uuid var?
-        $uuid = $this->uuid->toString();
 
         if (null === $this->family) {
             return $identifier;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
@@ -37,6 +37,7 @@ interface ProductInterface extends
 
     /**
      * @param string|null $identifierValue
+     * @deprecated Will be removed use addValue instead.
      *
      * @return self
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/IdentifierFormatGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/IdentifierFormatGuesser.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesserInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Length;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Symfony\Component\Validator\Constraints\Regex;
+
+/**
+ * Guesser
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IdentifierFormatGuesser implements ConstraintGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAttribute(AttributeInterface $attribute)
+    {
+        return $attribute->getType() === AttributeTypes::IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessConstraints(AttributeInterface $attribute)
+    {
+        return [
+            new Regex([
+                'pattern' => '/^(?!\s)[^,;]+(?<!\s)$/',
+                'message' => 'regex.comma_or_semicolon_or_surrounding_space.message'
+            ]),
+            new Regex([
+                'pattern' => '/^[^\r\n\f\v]+$/D',
+                'message' => 'regex.line_break.message'
+            ])
+        ];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/LengthGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/LengthGuesser.php
@@ -51,9 +51,8 @@ class LengthGuesser implements ConstraintGuesserInterface
         if ($maxCharacters = $attribute->getMaxCharacters()) {
             $characterLimit = min($maxCharacters, $characterLimit);
         }
-        $code = AttributeTypes::IDENTIFIER !== $attribute->getType() ? $attribute->getCode() : 'identifier';
 
-        $constraints[] = new Length(['max' => $characterLimit, 'attributeCode' => $code]);
+        $constraints[] = new Length(['max' => $characterLimit, 'attributeCode' => $attribute->getCode()]);
 
         return $constraints;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/UniqueIdentifierValueGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/UniqueIdentifierValueGuesser.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesserInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueValue;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+/**
+ * Guesser
+ *
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UniqueIdentifierValueGuesser implements ConstraintGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAttribute(AttributeInterface $attribute): bool
+    {
+        return $attribute->getType() === AttributeTypes::IDENTIFIER;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessConstraints(AttributeInterface $attribute): array
+    {
+        $constraint = new UniqueValue();
+        $constraint->message = 'The following identifier {{ attribute_code }} is already used for another product. Please modify the identifier to create or update this product.';
+
+        return [$constraint];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/UniqueValueGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/UniqueValueGuesser.php
@@ -19,7 +19,7 @@ class UniqueValueGuesser implements ConstraintGuesserInterface
     /**
      * {@inheritdoc}
      */
-    public function supportAttribute(AttributeInterface $attribute)
+    public function supportAttribute(AttributeInterface $attribute): bool
     {
         $availableTypes = [
             AttributeTypes::BACKEND_TYPE_TEXT,
@@ -28,18 +28,18 @@ class UniqueValueGuesser implements ConstraintGuesserInterface
             AttributeTypes::BACKEND_TYPE_DECIMAL
         ];
 
-        return in_array($attribute->getBackendType(), $availableTypes);
+        return in_array($attribute->getBackendType(), $availableTypes) && $attribute->getType() !== AttributeTypes::IDENTIFIER;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function guessConstraints(AttributeInterface $attribute)
+    public function guessConstraints(AttributeInterface $attribute): array
     {
         $constraints = [];
 
         // We don't apply the unique value constraint on identifier because it is done
-        // by `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductEntity`
+        // by `Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\UniqueIdentifierValueGuesser`
         if ($attribute->isUnique() && AttributeTypes::IDENTIFIER !== $attribute->getType()) {
             $constraints[] = new UniqueValue();
         }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Context/ProductContext.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Context/ProductContext.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Product\Test\Acceptance\Context;
 
 use Akeneo\Category\Infrastructure\Component\Classification\Repository\CategoryRepositoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ValueUserIntent;
@@ -48,7 +49,7 @@ final class ProductContext implements Context
     public function aProductWithIdentifierInTheCategory(string $identifier, string $categoryCode): void
     {
         $product = new Product();
-        $product->setIdentifier($identifier);
+        $product->addValue(IdentifierValue::value('sku', true, $identifier));
 
         $category = $this->categoryRepository->findOneByIdentifier($categoryCode);
         Assert::notNull($category);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/AssociationUserIntentCollectionApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/AssociationUserIntentCollectionApplierSpec.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProductModels;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateGroups;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
@@ -60,7 +61,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product,
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
             new ArrayCollection([$associatedProduct])
@@ -83,7 +84,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product,
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
             new ArrayCollection([$associatedProduct])
         );
@@ -113,7 +114,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product,
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
         $product->getAssociatedProducts('X_SELL')
             ->shouldBeCalledTimes(2)
             ->willReturn(new ArrayCollection([$associatedProduct]));
@@ -137,7 +138,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product,
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
             new ArrayCollection([$associatedProduct])
@@ -157,10 +158,10 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
     ) {
         $associatedProducts = [];
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
         $associatedProducts[] = $associatedProduct;
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('qux');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'qux'));
         $associatedProducts[] = $associatedProduct;
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
@@ -184,7 +185,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
             new ArrayCollection([$associatedProduct])
@@ -202,7 +203,7 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
         ProductInterface $product
     ) {
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledTimes(2)->willReturn(
             new ArrayCollection([$associatedProduct])
@@ -228,10 +229,10 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
     ) {
         $associatedProducts = [];
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
         $associatedProducts[] = $associatedProduct;
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('non_viewable_product');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'non_viewable_product'));
         $associatedProducts[] = $associatedProduct;
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(
@@ -297,10 +298,10 @@ class AssociationUserIntentCollectionApplierSpec extends ObjectBehavior
     ) {
         $associatedProducts = [];
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('baz');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'baz'));
         $associatedProducts[] = $associatedProduct;
         $associatedProduct = new Product();
-        $associatedProduct->setIdentifier('qux');
+        $associatedProduct->addValue(IdentifierValue::value('sku', true, 'qux'));
         $associatedProducts[] = $associatedProduct;
 
         $product->getAssociatedProducts('X_SELL')->shouldBeCalledOnce()->willReturn(

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductDatasource.php
@@ -159,7 +159,7 @@ class ProductDatasource extends Datasource
     {
         $attributeCodes = [];
         foreach ($attributes as $attribute) {
-            if (in_array($attribute['id'], $attributeIdsToDisplay)) {
+            if ((in_array($attribute['id'], $attributeIdsToDisplay) || (isset($attribute['mainIdentifier'])) && $attribute['mainIdentifier'])) {
                 $attributeCodes[] = $attribute['code'];
             }
         }

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductDatasourceSpec.php
@@ -68,6 +68,11 @@ class ProductDatasourceSpec extends ObjectBehavior
                     'id' => 3,
                     'code' => 'attribute_3'
                 ],
+                'sku' => [
+                    'id' => 4,
+                    'code' => 'sku',
+                    'mainIdentifier' => true,
+                ]
             ],
             'locale_code' => 'fr_FR',
             'scope_code' => 'ecommerce',
@@ -116,8 +121,9 @@ class ProductDatasourceSpec extends ObjectBehavior
             'document_type'    => null,
         ]);
 
+        // CPM-1082: mainIdentifier attribute should be kept for display purposes in the grid
         $subscriber
-            ->configure(FilterEntityWithValuesSubscriberConfiguration::filterEntityValues(['attribute_1', 'attribute_2']))
+            ->configure(FilterEntityWithValuesSubscriberConfiguration::filterEntityValues(['attribute_1', 'attribute_2', 'sku']))
             ->shouldBeCalled();
 
         $results = $this->getResults();

--- a/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
+++ b/tests/back/Acceptance/Attribute/InMemoryAttributeRepository.php
@@ -61,6 +61,18 @@ class InMemoryAttributeRepository implements AttributeRepositoryInterface, Saver
             throw new \InvalidArgumentException('The object argument should be a attribute');
         }
 
+        if (AttributeTypes::IDENTIFIER === $attribute->getType()) {
+            $mainIdentifier = $this->attributes->filter(
+                static fn (AttributeInterface $savedAttribute): bool =>
+                    $savedAttribute->isMainIdentifier() && $savedAttribute->getCode() !== $attribute->getCode()
+            )->isEmpty();
+
+            if ($mainIdentifier) {
+                $refl = new \ReflectionClass($attribute);
+                $refl->getProperty('mainIdentifier')->setValue($attribute, true);
+            }
+        }
+
         $this->attributes->set($attribute->getCode(), $attribute);
     }
 

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -45,6 +45,9 @@ class InMemoryGetAttributes implements GetAttributes
                     $attribute->isDecimalsAllowed(),
                     $attribute->getBackendType(),
                     $attribute->getAvailableLocaleCodes(),
+                    null,
+                    [],
+                    $attribute->isMainIdentifier()
                 );
             }
         }

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -6,6 +6,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Group;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Test\Acceptance\Common\NotImplementedException;
@@ -48,7 +49,7 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $attribute = new Attribute();
         $attribute->setCode('my_attribute');
         $product->addValue(ScalarValue::value($attribute, 'a-product'));
-        $product->setIdentifier('a-product');
+        $product->addValue(IdentifierValue::value('sku', true,'a-product'));
         $this->beConstructedWith([$product->getIdentifier() => $product]);
 
         $this->findOneByIdentifier('a-product')->shouldReturn($product);
@@ -65,7 +66,7 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $attribute = new Attribute();
         $attribute->setCode('my_attribute');
         $product->addValue(ScalarValue::value($attribute, 'a-product'));
-        $product->setIdentifier('a-product');
+        $product->addValue(IdentifierValue::value('sku', true, 'a-product'));
 
         $this->save($product)->shouldReturn(null);
 
@@ -95,11 +96,12 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_finds_all_products()
     {
         $product1 = new Product();
-        $product1->setIdentifier('product-1');
+        $product1->addValue(IdentifierValue::value('sku', true, 'product-1'));
+
         $this->save($product1);
 
         $product2 = new Product();
-        $product2->setIdentifier('product-2');
+        $product2->addValue(IdentifierValue::value('sku', true, 'product-2'));
         $this->save($product2);
 
         $this->findAll()->shouldReturn(['product-1' => $product1, 'product-2' => $product2]);
@@ -120,11 +122,12 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_returns_all_products()
     {
         $product1 = new Product();
-        $product1->setIdentifier('a-product');
+        $product1->addValue(IdentifierValue::value('sku', true, 'a-product'));
+
         $this->save($product1);
 
         $product2 = new Product();
-        $product2->setIdentifier('a-second-product');
+        $product2->addValue(IdentifierValue::value('sku', true, 'a-second-product'));
         $this->save($product2);
 
         $products = $this->findAll();
@@ -138,7 +141,7 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     {
         foreach (['A', 'B', 'C'] as $identifier) {
             $product = new Product();
-            $product->setIdentifier($identifier);
+            $product->addValue(IdentifierValue::value('sku', true, $identifier));
             $this->save($product);
         }
 
@@ -152,11 +155,11 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_finds_products_by_criteria()
     {
         $productA = new Product();
-        $productA->setIdentifier('A');
+        $productA->addValue(IdentifierValue::value('sku', true, 'A'));
         $this->save($productA);
 
         $productB = new Product();
-        $productB->setIdentifier('B');
+        $productB->addValue(IdentifierValue::value('sku', true, 'B'));
         $this->save($productB);
 
         $products = $this->findBy(['identifier' => 'A']);
@@ -168,11 +171,11 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_finds_one_product_by_uuid()
     {
         $productA = new Product();
-        $productA->setIdentifier('A');
+        $productA->addValue(IdentifierValue::value('sku', true, 'A'));
         $this->save($productA);
 
         $productB = new Product();
-        $productB->setIdentifier('B');
+        $productB->addValue(IdentifierValue::value('sku', true, 'B'));
         $this->save($productB);
 
         $this->findOneBy(['uuid' => $productA->getUuid()])->shouldBe($productA);
@@ -183,10 +186,10 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
     function it_gets_products_by_uuids()
     {
         $product1 = new Product();
-        $product1->setIdentifier('foo');
+        $product1->addValue(IdentifierValue::value('sku', true, 'foo'));
         $this->save($product1);
         $product2 = new Product();
-        $product2->setIdentifier('bar');
+        $product2->addValue(IdentifierValue::value('sku', true, 'bar'));
         $this->save($product2);
 
         $this->getItemsFromUuids(

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -104,7 +104,10 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $product2->addValue(IdentifierValue::value('sku', true, 'product-2'));
         $this->save($product2);
 
-        $this->findAll()->shouldReturn(['product-1' => $product1, 'product-2' => $product2]);
+        $this->findAll()->shouldReturn([
+            $product1->getUuid()->toString() => $product1,
+            $product2->getUuid()->toString() => $product2,
+        ]);
     }
 
     function it_asserts_that_the_other_methods_are_not_implemented_yet()
@@ -133,8 +136,8 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $products = $this->findAll();
         $products->shouldBeArray();
         $products->shouldHaveCount(2);
-        $products['a-product']->shouldBe($product1);
-        $products['a-second-product']->shouldBe($product2);
+        $products[$product1->getUuid()->toString()]->shouldBe($product1);
+        $products[$product2->getUuid()->toString()]->shouldBe($product2);
     }
 
     function it_returns_products_from_identifiers()
@@ -165,7 +168,7 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $products = $this->findBy(['identifier' => 'A']);
         $products->shouldBeArray();
         $products->shouldHaveCount(1);
-        $products->shouldHaveKeyWithValue('A', $productA);
+        $products->shouldHaveKeyWithValue($productA->getUuid()->toString(), $productA);
     }
 
     function it_finds_one_product_by_uuid()

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
@@ -169,7 +169,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
                 new ReadValueCollection([
                     OptionValue::value('a_simple_select', 'optionA'),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_A_false'),
+                    IdentifierValue::value('sku', true, 'apollon_A_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -229,7 +229,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
                 new ReadValueCollection([
                     OptionValue::value('a_simple_select', 'optionB'),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_B_false'),
+                    IdentifierValue::value('sku', true, 'apollon_B_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -429,7 +429,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
             new ReadValueCollection([
                 OptionValue::value('a_simple_select', 'optionB'),
                 PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                IdentifierValue::value('sku', false, 'apollon_B_false'),
+                IdentifierValue::value('sku', true, 'apollon_B_false'),
                 ScalarValue::value('a_yes_no', false),
                 NumberValue::value('a_number_float', '12.5000'),
                 ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -493,7 +493,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
                 new ReadValueCollection([
                     OptionValue::value('a_simple_select', 'optionA'),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_A_false'),
+                    IdentifierValue::value('sku', true, 'apollon_A_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -553,7 +553,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
                 new ReadValueCollection([
                     OptionValue::value('a_simple_select', 'optionB'),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_B_false'),
+                    IdentifierValue::value('sku', true, 'apollon_B_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
@@ -155,7 +155,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
                 new ReadValueCollection([
                     new OptionValueWithLinkedData('a_simple_select','optionA', null, null, ['attribute' => 'a_simple_select', 'code' => 'optionA', 'labels' => ['en_US' => 'Option A',],]),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_A_false'),
+                    IdentifierValue::value('sku', true, 'apollon_A_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -211,7 +211,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
                 new ReadValueCollection([
                     new OptionValueWithLinkedData('a_simple_select','optionB', null, null, ['attribute' => 'a_simple_select', 'code' => 'optionB', 'labels' => ['en_US' => 'Option B',],]),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_B_false'),
+                    IdentifierValue::value('sku', true, 'apollon_B_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -401,7 +401,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
             new ReadValueCollection([
                 new OptionValueWithLinkedData('a_simple_select','optionB', null, null, ['attribute' => 'a_simple_select', 'code' => 'optionB', 'labels' => ['en_US' => 'Option B',],]),
                 PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                IdentifierValue::value('sku', false, 'apollon_B_false'),
+                IdentifierValue::value('sku', true, 'apollon_B_false'),
                 ScalarValue::value('a_yes_no', false),
                 NumberValue::value('a_number_float', '12.5000'),
                 ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -467,7 +467,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
                 new ReadValueCollection([
                     new OptionValueWithLinkedData('a_simple_select','optionA', null, null, ['attribute' => 'a_simple_select', 'code' => 'optionA', 'labels' => ['en_US' => 'Option A',],]),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_A_false'),
+                    IdentifierValue::value('sku', true, 'apollon_A_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
@@ -523,7 +523,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
                 new ReadValueCollection([
                     new OptionValueWithLinkedData('a_simple_select','optionB', null, null, ['attribute' => 'a_simple_select', 'code' => 'optionB', 'labels' => ['en_US' => 'Option B',],]),
                     PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
-                    IdentifierValue::value('sku', false, 'apollon_B_false'),
+                    IdentifierValue::value('sku', true, 'apollon_B_false'),
                     ScalarValue::value('a_yes_no', false),
                     NumberValue::value('a_number_float', '12.5000'),
                     ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -36,8 +36,8 @@ class ProductIdentifierValidationIntegration extends TestCase
         $violations = $this->validateProduct($product);
 
         $this->assertCount(1, $violations);
-        $this->assertSame($violations->get(0)->getMessage(), 'This field should not contain any line break');
-        $this->assertSame($violations->get(0)->getPropertyPath(), 'identifier');
+        $this->assertSame('This field should not contain any line break', $violations->get(0)->getMessage());
+        $this->assertSame('values[sku-<all_channels>-<all_locales>].data', $violations->get(0)->getPropertyPath());
 
         $this->saveProduct($product);
     }
@@ -56,8 +56,8 @@ class ProductIdentifierValidationIntegration extends TestCase
         $violations = $this->validateProduct($wrongProduct);
         $this->assertCount(1, $violations);
         $this->assertSame(
-            $violations->get(0)->getMessage(),
-            'The identifier attribute must not contain more than 4 characters. The submitted value is too long.'
+            'The sku attribute must not contain more than 4 characters. The submitted value is too long.',
+            $violations->get(0)->getMessage()
         );
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductCr
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
@@ -58,7 +59,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product, ['is_new' => true, 'unitary' => true]));
 
@@ -89,7 +90,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product, ['is_new' => false, 'unitary' => true]));
 
@@ -120,9 +121,9 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product1 = new Product();
-        $product1->setIdentifier('product_identifier_1');
+        $product1->addValue(IdentifierValue::value('sku', true, 'product_identifier_1'));
         $product2 = new Product();
-        $product2->setIdentifier('product_identifier_2');
+        $product2->addValue(IdentifierValue::value('sku', true, 'product_identifier_2'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
         $this->createAndDispatchPimEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
@@ -163,11 +164,11 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 2, new NullLogger(), new NullLogger()); // Bulk size of 2
 
         $product1 = new Product();
-        $product1->setIdentifier('product_identifier_1');
+        $product1->addValue(IdentifierValue::value('sku', true, 'product_identifier_1'));
         $product2 = new Product();
-        $product2->setIdentifier('product_identifier_2');
+        $product2->addValue(IdentifierValue::value('sku', true, 'product_identifier_2'));
         $product3 = new Product();
-        $product3->setIdentifier('product_identifier_3');
+        $product3->addValue(IdentifierValue::value('sku', true, 'product_identifier_3'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
         $this->createAndDispatchPimEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
@@ -229,7 +230,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $security->getUser()->willReturn(null);
 
@@ -247,7 +248,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
@@ -272,7 +273,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $security->getUser()->willReturn($user);
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $this->createAndDispatchPimEvents(new GenericEvent(
             $product,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedP
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductRemovedEventSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
@@ -59,7 +60,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('blue_jean');
+        $product->addValue(IdentifierValue::value('sku', true, 'blue_jean'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product, ['unitary' => true]));
 
@@ -94,9 +95,9 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product1 = new Product();
-        $product1->setIdentifier('product_identifier_1');
+        $product1->addValue(IdentifierValue::value('sku', true, 'product_identifier_1'));
         $product2 = new Product();
-        $product2->setIdentifier('product_identifier_2');
+        $product2->addValue(IdentifierValue::value('sku', true, 'product_identifier_2'));
 
         $this->createAndDispatchPimEvents(new GenericEvent($product1, ['unitary' => false]));
         $this->createAndDispatchPimEvents(new GenericEvent($product2, ['unitary' => false]));
@@ -153,7 +154,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $security->getUser()->willReturn(null);
 
@@ -181,7 +182,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $security->getUser()->willReturn($user);
 
         $product = new Product();
-        $product->setIdentifier('product_identifier');
+        $product->addValue(IdentifierValue::value('sku', true, 'product_identifier'));
 
         $this->createAndDispatchPimEvents(new GenericEvent(
             $product,

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -149,7 +149,6 @@ class ProductSpec extends ObjectBehavior
 
         $this->setFamily($family);
         $this->setValues($values);
-        $this->setIdentifier('shovel');
 
         $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petit outil agricole authentique');
     }
@@ -173,7 +172,6 @@ class ProductSpec extends ObjectBehavior
 
         $this->setFamily($family);
         $this->setValues($values);
-        $this->setIdentifier('shovel');
 
         $this->getLabel('fr_FR', 'mobile')->shouldReturn('Petite pelle');
     }
@@ -188,8 +186,9 @@ class ProductSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
 
         $this->setFamily(null);
-        $this->setValues(new WriteValueCollection());
-        $this->setIdentifier('shovel');
+        $this->setValues(new WriteValueCollection([
+            IdentifierValue::value('sku', true, 'shovel')
+        ]));
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
     }
@@ -208,8 +207,9 @@ class ProductSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
 
         $this->setFamily($family);
-        $this->setValues(new WriteValueCollection());
-        $this->setIdentifier('shovel');
+        $this->setValues(new WriteValueCollection([
+            IdentifierValue::value('sku', true, 'shovel')
+        ]));
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
     }
@@ -225,7 +225,9 @@ class ProductSpec extends ObjectBehavior
         $attributeAsLabel->isScopable()->willReturn(false);
 
         $this->setFamily($family);
-        $this->setIdentifier('shovel');
+        $this->setValues(new WriteValueCollection([
+            IdentifierValue::value('sku', true, 'shovel')
+        ]));
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/AssociationFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/AssociationFieldSetterSpec.php
@@ -22,6 +22,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\AssociationFieldSette
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\FieldSetterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\SetterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Structure\Component\Model\AssociationType;
 use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
 use Akeneo\Pim\Structure\Component\Repository\AssociationTypeRepositoryInterface;
@@ -159,9 +160,9 @@ class AssociationFieldSetterSpec extends ObjectBehavior
 
         $product->getAssociations()->willReturn(new ArrayCollection([$xsellAssociation->getWrappedObject()]));
 
-        $assocProductOne = (new Product())->setIdentifier('assocProductOne');
-        $assocProductTwo = (new Product())->setIdentifier('assocProductTwo');
-        $assocProductThree = (new Product())->setIdentifier('assocProductThree');
+        $assocProductOne = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductOne'));
+        $assocProductTwo = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductTwo'));
+        $assocProductThree = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductThree'));
         $assocProductModelOne = new ProductModel();
         $assocProductModelOne->setCode('assocProductModelOne');
         $assocProductModelTwo = new ProductModel();
@@ -232,9 +233,9 @@ class AssociationFieldSetterSpec extends ObjectBehavior
 
         $product->getAssociations()->willReturn(new ArrayCollection([$xsellAssociation->getWrappedObject()]));
 
-        $assocProductOne = (new Product())->setIdentifier('assocProductOne');
-        $assocProductTwo = (new Product())->setIdentifier('assocProductTwo');
-        $assocProductThree = (new Product())->setIdentifier('assocProductThree');
+        $assocProductOne = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductOne'));
+        $assocProductTwo = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductTwo'));
+        $assocProductThree = (new Product())->addValue(IdentifierValue::value('sku', true, 'assocProductThree'));
 
         $productRepository->find($assocProductOne->getUuid()->toString())->willReturn($assocProductOne);
         $productRepository->find($assocProductTwo->getUuid()->toString())->willReturn($assocProductTwo);
@@ -279,7 +280,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $product = new Product();
         $product->addAssociation($compatibilityAssociation);
 
-        $productAssociated = (new Product())->setIdentifier('productAssociated');
+        $productAssociated = (new Product())->addValue(IdentifierValue::value('sku', true, 'productAssociated'));
 
         $productModelAssociated = new ProductModel();
         $productModelAssociated->setCode('productModelAssociated');
@@ -318,7 +319,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $compatibilityAssociationType->setCode('COMPATIBILITY');
         $associationTypeRepository->findOneByIdentifier('COMPATIBILITY')->willReturn($compatibilityAssociationType);
 
-        $productAssociated = (new Product())->setIdentifier('productAssociated');
+        $productAssociated = (new Product())->addValue(IdentifierValue::value('sku', true, 'productAssociated'));
 
         $productModelAssociated = new ProductModel();
         $productModelAssociated->setCode('productModelAssociated');
@@ -365,7 +366,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $compatibilityAssociationType->setCode('COMPATIBILITY');
         $associationTypeRepository->findOneByIdentifier('COMPATIBILITY')->willReturn($compatibilityAssociationType);
 
-        $productAssociated = (new Product())->setIdentifier('productAssociated');
+        $productAssociated = (new Product())->addValue(IdentifierValue::value('sku', true, 'productAssociated'));
 
         $productModelAssociated = new ProductModel();
         $productModelAssociated->setCode('productModelAssociated');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/LengthGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/LengthGuesserSpec.php
@@ -15,6 +15,7 @@ class LengthGuesserSpec extends ObjectBehavior
         $text->getType()->willReturn('pim_catalog_text');
         $text->getCode()->willReturn('a_text');
         $identifier->getType()->willReturn('pim_catalog_identifier');
+        $identifier->getCode()->willReturn('sku');
         $textarea->getType()->willReturn('pim_catalog_textarea');
         $textarea->getCode()->willReturn('a_textarea');
     }
@@ -40,7 +41,7 @@ class LengthGuesserSpec extends ObjectBehavior
         $this->supportAttribute($image)->shouldReturn(false);
     }
 
-    function it_enforces_the_keyword_identifier_instead_of_attribute_code($identifier)
+    function it_applies_the_same_constraint_for_an_identifier_attribute_as_it_does_the_others($identifier)
     {
         $identifier->getMaxCharacters()->willReturn(null);
         $lengthConstraints = $this->guessConstraints($identifier);
@@ -48,7 +49,7 @@ class LengthGuesserSpec extends ObjectBehavior
         $lengthConstraints->shouldHaveCount(1);
         $lengthConstraints[0]->shouldBeAnInstanceOf(Length::class);
         $lengthConstraints[0]->max->shouldBe(255);
-        $lengthConstraints[0]->attributeCode->shouldBe('identifier');
+        $lengthConstraints[0]->attributeCode->shouldBe('sku');
     }
 
     function it_enforces_database_length_constraints($text, $textarea)

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/UniqueValueGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/UniqueValueGuesserSpec.php
@@ -23,11 +23,11 @@ class UniqueValueGuesserSpec extends ObjectBehavior
 
     public function it_enforces_attribute_type(AttributeInterface $attribute)
     {
-        foreach ($this->dataProviderForSupportedAttributes() as $attributeTypeTest) {
-            $attributeType = $attributeTypeTest[0];
+        foreach ($this->dataProviderForSupportedAttributes() as $attributeType => $attributeTypeTest) {
+            $attributeBackendType = $attributeTypeTest[0];
             $expectedResult = $attributeTypeTest[1];
-            $attribute->getBackendType()
-                ->willReturn($attributeType);
+            $attribute->getBackendType()->willReturn($attributeBackendType);
+            $attribute->getType()->willReturn('pim_catalog_' . $attributeType);
             $this->supportAttribute($attribute)->shouldReturn($expectedResult);
         }
     }
@@ -86,6 +86,7 @@ class UniqueValueGuesserSpec extends ObjectBehavior
             'price'      => [AttributeTypes::BACKEND_TYPE_PRICE, false],
             'textarea'   => [AttributeTypes::BACKEND_TYPE_TEXTAREA, false],
             'text'       => [AttributeTypes::BACKEND_TYPE_TEXT, true],
+            'identifier' => [AttributeTypes::BACKEND_TYPE_TEXT, false],
         ];
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -353,7 +353,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $axes = [$autoExposure];
 
         $entity = new Product();
-        $entity->setIdentifier('my_identifier');
+        $entity->addValue(IdentifierValue::value('sku', true, 'my_identifier'));
         $entity->setParent($parent->getWrappedObject());
         $entity->setFamilyVariant($familyVariant->getWrappedObject());
         $entity->addValue(ScalarValue::value('auto_exposure', false));
@@ -377,7 +377,7 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
                     '%sibling_with_same_value%' => 'sibling2',
                 ]
             )
-            ->willReturn($violation);
+            ->shouldBeCalled()->willReturn($violation);
         $violation->atPath('attribute')->willReturn($violation);
         $violation->addViolation()->shouldBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueVariantAxisValidatorSpec.php
@@ -13,6 +13,7 @@ use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetValuesOfSiblin
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxis;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\UniqueVariantAxisValidator;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueAxesCombinationSet;
+use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
@@ -193,7 +194,6 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariant,
         ProductModelInterface $parent,
         AttributeInterface $color,
-        WriteValueCollection $valuesOfSibling,
         UniqueVariantAxis $constraint
     ) {
         $axes = [$color];
@@ -202,10 +202,12 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $entity->setParent($parent->getWrappedObject());
         $entity->setFamilyVariant($familyVariant->getWrappedObject());
         $entity->addValue(OptionValue::value('color', 'blue'));
+        $entity->addValue(IdentifierValue::value('sku',true, 'blue_variant'));
 
         $axesProvider->getAxes($entity)->willReturn($axes);
         $color->getCode()->willReturn('color');
 
+        $valuesOfSibling = new WriteValueCollection([IdentifierValue::value('sku', true, 'sibbling_identifier')]);
         $getValuesOfSiblings->for($entity, ['color'])->willReturn(
             [
                 'sibbling_identifier' => $valuesOfSibling,
@@ -306,10 +308,10 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $axes = [$color];
 
         $entity = new Product();
-        $entity->setIdentifier('my_identifier');
         $entity->setParent($parent->getWrappedObject());
         $entity->setFamilyVariant($familyVariant->getWrappedObject());
         $entity->addValue(OptionValue::value('color', 'blue'));
+        $entity->addValue(IdentifierValue::value('sku', true, 'my_identifier'));
 
         $axesProvider->getAxes($entity)->willReturn($axes);
 
@@ -396,10 +398,10 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $axes = [$color];
 
         $entity = new Product();
-        $entity->setIdentifier('my_identifier');
         $entity->setParent($parent->getWrappedObject());
         $entity->setFamilyVariant($familyVariant->getWrappedObject());
         $entity->addValue(OptionValue::value('color', 'Blue'));
+        $entity->addValue(IdentifierValue::value('sku', true, 'my_identifier'));
 
         $axesProvider->getAxes($entity)->willReturn($axes);
 
@@ -443,11 +445,11 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $axes = [$color, $size];
 
         $entity = new Product();
-        $entity->setIdentifier('entity_code');
         $entity->setParent($parent->getWrappedObject());
         $entity->setFamilyVariant($familyVariant->getWrappedObject());
         $entity->addValue(OptionValue::value('color', 'blue'));
         $entity->addValue(OptionValue::value('size', 'xl'));
+        $entity->addValue(IdentifierValue::value('sku', true, 'entity_code'));
 
         $axesProvider->getAxes($entity)->willReturn($axes);
 
@@ -542,16 +544,16 @@ class UniqueVariantAxisValidatorSpec extends ObjectBehavior
         $color->getCode()->willReturn('color');
 
         $entity1 = new Product();
-        $entity1->setIdentifier('entity_1');
         $entity1->setParent($parent->getWrappedObject());
         $entity1->setFamilyVariant($familyVariant->getWrappedObject());
         $entity1->addValue(OptionValue::value('color', 'blue'));
+        $entity1->addValue(IdentifierValue::value('sku', true, 'entity_1'));
 
         $entity2 = new Product();
-        $entity2->setIdentifier('entity_2');
         $entity2->setParent($parent->getWrappedObject());
         $entity2->setFamilyVariant($familyVariant->getWrappedObject());
         $entity2->addValue(OptionValue::value('color', 'blue'));
+        $entity2->addValue(IdentifierValue::value('sku', true,'entity_2'));
 
         $getValuesOfSiblings->for($entity1, ['color'])->shouldBeCalled()->willReturn([]);
         $getValuesOfSiblings->for($entity2, ['color'])->willReturn([]);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
@@ -173,9 +173,9 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $productModel->setFamilyVariant($familyVariant);
 
         $variantProduct = new Product();
-        $variantProduct->setIdentifier('4f8db754-4eff-4b67-bdba-6eac4d17f622');
         $variantProduct->setParent($productModel);
         $variantProduct->setFamilyVariant($familyVariant);
+        $variantProduct->addValue(IdentifierValue::value('sku', true, '4f8db754-4eff-4b67-bdba-6eac4d17f622'));
 
         $duplicateProduct = new Product('4f8db754-4eff-4b67-bdba-6eac4d17f622');
         $duplicateProduct->setParent($productModel);

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
@@ -18,7 +18,7 @@ Feature: Validate identifier attribute of a product
     When I am on the "foo" product page
     And I change the SKU to "sku-0000000"
     And I save the product
-    Then I should see validation tooltip "The identifier attribute must not contain more than 10 characters. The submitted value is too long."
+    Then I should see validation tooltip "The sku attribute must not contain more than 10 characters. The submitted value is too long."
     And there should be 1 error in the "Other" tab
 
   Scenario: Validate the regexp validation rule constraint of identifier attribute
@@ -38,5 +38,5 @@ Feature: Validate identifier attribute of a product
     Given I am on the "bar" product page
     When I change the SKU to an invalid value
     And I save the product
-    Then I should see validation tooltip "The identifier attribute must not contain more than 255 characters. The submitted value is too long."
+    Then I should see validation tooltip "The sku attribute must not contain more than 255 characters. The submitted value is too long."
     And there should be 1 error in the "Other" tab


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The method `getIdentifier` in `AbstractProduct` will now retrieve the value of type `IdentifierValue` which has the isMainIdentifier property.
`setIdentifier` is now useless because the data is retrieved from the values rather than the property `identifier` of the class.

As `setIdentiier` is deprecated, all calls are removed : 
- The validation for a uniqueness and length of an identifier attribute is moved to the ConstraintsGuesser
- The validation message for an invalid identifier value is changed
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
