### PR TITLE
RAB-1329: Validate no job running before resetting PIM

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -488,8 +488,8 @@ pim_system:
     button:
       label: Reset instance
       confirm: Reset and log out
-    error_notification: An error occurred during the PIM reset, please contact system administrator.
-    jobs_running: You cannot reset the PIM at the moment as some jobs are still queued or running.
+    error_notification: An error occurred during instance reset, please contact your system administrator.
+    jobs_running: You cannot reset your instance at the moment as some jobs are still queued or running.
   sandbox:
     helper:
       text: This is a sandbox environment; your changes will not impact your production.

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -489,7 +489,7 @@ pim_system:
       label: Reset instance
       confirm: Reset and log out
     error_notification: An error occurred during instance reset, please contact your system administrator.
-    jobs_running: You cannot reset your instance at the moment as some jobs are still queued or running.
+    jobs_running: You cannot reset your instance at the moment, as some processes are still queued or running.
   sandbox:
     helper:
       text: This is a sandbox environment; your changes will not impact your production.

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -489,6 +489,7 @@ pim_system:
       label: Reset instance
       confirm: Reset and log out
     error_notification: An error occurred during the PIM reset, please contact system administrator.
+    jobs_running: You cannot reset the PIM at the moment as some jobs are still queued or running.
   sandbox:
     helper:
       text: This is a sandbox environment; your changes will not impact your production.

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/components/reset-pim/ResetButton.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/components/reset-pim/ResetButton.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
 import {Button, useBooleanState} from 'akeneo-design-system';
-import {useTranslate} from '@akeneo-pim-community/shared';
+import {NotificationLevel, useNotify, useTranslate} from '@akeneo-pim-community/shared';
 import {ResetModal} from './ResetModal';
+import {useCheckInstanceCanBeReset} from '../../hooks';
 
 const ResetButton = () => {
   const translate = useTranslate();
+  const notify = useNotify();
   const [isResetModalOpen, openResetModal, closeResetModal] = useBooleanState(false);
+  const [isLoading, checkInstanceCanBeReset] = useCheckInstanceCanBeReset();
+
+  const handleOpenModal = async () => {
+    try {
+      await checkInstanceCanBeReset();
+
+      openResetModal();
+    } catch (error) {
+      notify(NotificationLevel.ERROR, translate('pim_system.reset_pim.jobs_running'));
+    }
+  };
 
   return (
     <>
-      <Button level="danger" ghost={true} onClick={openResetModal}>
+      <Button level="danger" ghost={true} disabled={isLoading} onClick={handleOpenModal}>
         {translate('pim_system.reset_pim.button.label')}
       </Button>
       {isResetModalOpen && <ResetModal onConfirm={closeResetModal} onCancel={closeResetModal} />}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/components/reset-pim/ResetButton.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/components/reset-pim/ResetButton.unit.tsx
@@ -1,15 +1,46 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import {screen} from '@testing-library/react';
-import {renderWithProviders} from '@akeneo-pim-community/shared';
+import {act, screen} from '@testing-library/react';
+import {NotificationLevel, renderWithProviders} from '@akeneo-pim-community/shared';
 import {ResetButton} from './ResetButton';
 
-test('it opens a modal when clicking on the button', () => {
+const mockedNotify = jest.fn();
+jest.mock('@akeneo-pim-community/shared', () => ({
+  ...jest.requireActual('@akeneo-pim-community/shared'),
+  useNotify: () => mockedNotify,
+}));
+
+beforeEach(() => {
+  mockedNotify.mockClear();
+});
+
+let mockedCheckInstance = jest.fn();
+jest.mock('../../hooks/useCheckInstanceCanBeReset', () => ({
+  useCheckInstanceCanBeReset: () => [false, mockedCheckInstance],
+}));
+
+test('it opens a modal when clicking on the button and if the PIM can be reset', async () => {
   renderWithProviders(<ResetButton />);
 
   expect(screen.queryByText('pim_system.reset_pim.modal.summary.title')).not.toBeInTheDocument();
 
-  userEvent.click(screen.getByText('pim_system.reset_pim.button.label'));
+  await act(async () => {
+    userEvent.click(screen.getByText('pim_system.reset_pim.button.label'));
+  });
 
   expect(screen.getByText('pim_system.reset_pim.modal.summary.title')).toBeInTheDocument();
+});
+
+test('it notifies when the reset PIM cannot happen', async () => {
+  mockedCheckInstance = jest.fn(() => {
+    throw new Error('Some jobs are still running');
+  });
+
+  renderWithProviders(<ResetButton />);
+
+  await act(async () => {
+    userEvent.click(screen.getByText('pim_system.reset_pim.button.label'));
+  });
+
+  expect(mockedNotify).toHaveBeenCalledWith(NotificationLevel.ERROR, 'pim_system.reset_pim.jobs_running');
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/index.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/index.ts
@@ -1,2 +1,3 @@
+export * from './useCheckInstanceCanBeReset';
 export * from './useCountEntities';
 export * from './useResetInstance';

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/useCheckInstanceCanBeReset.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/useCheckInstanceCanBeReset.ts
@@ -1,0 +1,29 @@
+import {useBooleanState} from 'akeneo-design-system';
+import {useRoute} from '@akeneo-pim-community/shared';
+
+const useCheckInstanceCanBeReset = () => {
+  const route = useRoute('akeneo_installer_check_reset_instance');
+  const [isLoading, startLoading, stopLoading] = useBooleanState(false);
+
+  const checkInstanceCanBeReset = async () => {
+    startLoading();
+    const response = await fetch(route, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    });
+
+    stopLoading();
+    if (response.ok) {
+      return;
+    }
+
+    throw Error(response.statusText);
+  };
+
+  return [isLoading, checkInstanceCanBeReset] as const;
+};
+
+export {useCheckInstanceCanBeReset};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/useCheckInstanceCanBeReset.unit.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/hooks/useCheckInstanceCanBeReset.unit.ts
@@ -1,0 +1,37 @@
+import {renderHookWithProviders} from '@akeneo-pim-community/legacy-bridge/tests/front/unit/utils';
+import fetchMock from 'jest-fetch-mock';
+import {useCheckInstanceCanBeReset} from './useCheckInstanceCanBeReset';
+import {act} from 'react-test-renderer';
+
+const flushPromises = () => new Promise(setImmediate);
+
+test('it can check if the PIM can be reset', async () => {
+  fetchMock.mockResponseOnce('', {
+    status: 200,
+  });
+
+  const {result} = renderHookWithProviders(useCheckInstanceCanBeReset);
+  const [isLoading, checkInstanceCanBeReset] = result.current;
+
+  expect(isLoading).toBe(false);
+  act(() => {
+    checkInstanceCanBeReset();
+  });
+
+  expect(result.current[0]).toBe(true);
+  await act(async () => {
+    await flushPromises();
+  });
+
+  expect(result.current[0]).toBe(false);
+});
+
+test('it throws an error when the PIM cannot be reset', async () => {
+  fetchMock.mockResponseOnce('', {status: 400, statusText: 'Cannot reset the PIM'});
+  const {result} = renderHookWithProviders(useCheckInstanceCanBeReset);
+  const [, checkInstanceCanBeReset] = result.current;
+
+  await expect(async () => {
+    await act(async () => await checkInstanceCanBeReset());
+  }).rejects.toThrow(Error);
+});

--- a/src/Akeneo/Platform/Installer/back/src/Infrastructure/Controller/CheckInstanceCanBeResetAction.php
+++ b/src/Akeneo/Platform/Installer/back/src/Infrastructure/Controller/CheckInstanceCanBeResetAction.php
@@ -9,28 +9,21 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Installer\Infrastructure\Controller;
 
-use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface;
-use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionQuery;
+use Akeneo\Platform\Job\ServiceApi\JobExecution\FindQueuedAndRunningJobExecutionInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckInstanceCanBeResetAction
 {
     public function __construct(
-        //TODO service api in Job
-        private readonly SearchJobExecutionInterface $searchJobExecution,
+        private readonly FindQueuedAndRunningJobExecutionInterface $findQueuedAndRunningJobExecution,
     ) {
     }
 
     public function __invoke(): JsonResponse
     {
-        $query = new SearchJobExecutionQuery();
-        $query->size = 1;
-        $query->status = ['STARTING', 'IN_PROGRESS'];
-
-        $queuedAndRunningJobExecutions = $this->searchJobExecution->search($query);
-
-        $status = empty($queuedAndRunningJobExecutions) ? Response::HTTP_NO_CONTENT : Response::HTTP_BAD_REQUEST;
+        $count = $this->findQueuedAndRunningJobExecution->count(1);
+        $status = 0 === $count ? Response::HTTP_NO_CONTENT : Response::HTTP_BAD_REQUEST;
 
         return new JsonResponse(null, $status);
     }

--- a/src/Akeneo/Platform/Installer/back/src/Infrastructure/Controller/CheckInstanceCanBeResetAction.php
+++ b/src/Akeneo/Platform/Installer/back/src/Infrastructure/Controller/CheckInstanceCanBeResetAction.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Platform\Installer\Infrastructure\Controller;
+
+use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface;
+use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionQuery;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckInstanceCanBeResetAction
+{
+    public function __construct(
+        //TODO service api in Job
+        private readonly SearchJobExecutionInterface $searchJobExecution,
+    ) {
+    }
+
+    public function __invoke(): JsonResponse
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 1;
+        $query->status = ['STARTING', 'IN_PROGRESS'];
+
+        $queuedAndRunningJobExecutions = $this->searchJobExecution->search($query);
+
+        $status = empty($queuedAndRunningJobExecutions) ? Response::HTTP_NO_CONTENT : Response::HTTP_BAD_REQUEST;
+
+        return new JsonResponse(null, $status);
+    }
+}

--- a/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -4,3 +4,8 @@ services:
     arguments:
       - '@Akeneo\Platform\Installer\Application\ResetInstance\ResetInstanceHandler'
       - '@oro_security.security_facade'
+
+  Akeneo\Platform\Installer\Infrastructure\Controller\CheckInstanceCanBeResetAction:
+    public: true
+    arguments:
+      - '@Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface'

--- a/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -8,4 +8,4 @@ services:
   Akeneo\Platform\Installer\Infrastructure\Controller\CheckInstanceCanBeResetAction:
     public: true
     arguments:
-      - '@Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface'
+      - '@Akeneo\Platform\Job\ServiceApi\JobExecution\FindQueuedAndRunningJobExecutionInterface'

--- a/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Platform/Installer/back/src/Infrastructure/Symfony/Resources/config/routing.yml
@@ -4,3 +4,10 @@ akeneo_installer_reset_instance:
     _controller: Akeneo\Platform\Installer\Infrastructure\Controller\ResetInstanceAction
     _feature: reset_pim
   methods: [ POST ]
+
+akeneo_installer_check_reset_instance:
+  path: /rest/check-reset-instance
+  defaults:
+    _controller: Akeneo\Platform\Installer\Infrastructure\Controller\CheckInstanceCanBeResetAction
+    _feature: reset_pim
+  methods: [ GET ]

--- a/src/Akeneo/Platform/Installer/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Installer/back/tests/.php_cd.php
@@ -25,6 +25,7 @@ $rules = [
         [
             'Akeneo\Platform\Installer\Application',
             'Akeneo\Platform\Installer\Domain',
+            'Akeneo\Platform\Job\ServiceApi',
             'Doctrine\DBAL\Connection',
             'Symfony\Component',
             'Webmozart\Assert\Assert',

--- a/src/Akeneo/Platform/Installer/back/tests/Integration/Controller/CheckInstanceCanBeResetActionTest.php
+++ b/src/Akeneo/Platform/Installer/back/tests/Integration/Controller/CheckInstanceCanBeResetActionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Installer\Test\Integration\Controller;
+
+use Akeneo\Platform\Job\Test\Integration\ControllerIntegrationTestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckInstanceCanBeResetActionTest extends ControllerIntegrationTestCase
+{
+    private const ROUTE = 'akeneo_installer_check_reset_instance';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logAs('julia');
+    }
+
+    public function test_it_returns_ok_when_no_job_is_queued_or_running(): void
+    {
+        $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
+
+        $response = $this->client->getResponse();
+        Assert::assertSame($response->getStatusCode(), Response::HTTP_OK);
+    }
+
+    public function test_it_returns_failure_when_a_job_is_queued(): void
+    {
+        //given a queued job execution queued
+
+        $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
+
+        $response = $this->client->getResponse();
+        Assert::assertSame($response->getStatusCode(), Response::HTTP_BAD_REQUEST);
+    }
+
+    public function test_it_returns_failure_when_a_job_is_running(): void
+    {
+        //given a queued job execution running
+
+        $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
+
+        $response = $this->client->getResponse();
+        Assert::assertSame($response->getStatusCode(), Response::HTTP_BAD_REQUEST);
+    }
+}

--- a/src/Akeneo/Platform/Installer/back/tests/Integration/Controller/CheckInstanceCanBeResetActionTest.php
+++ b/src/Akeneo/Platform/Installer/back/tests/Integration/Controller/CheckInstanceCanBeResetActionTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Installer\Test\Integration\Controller;
 
-use Akeneo\Platform\Job\Test\Integration\ControllerIntegrationTestCase;
+use Akeneo\Platform\Installer\Test\Integration\ControllerIntegrationTestCase;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Tool\Component\Batch\Job\BatchStatus;
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -12,11 +15,15 @@ class CheckInstanceCanBeResetActionTest extends ControllerIntegrationTestCase
 {
     private const ROUTE = 'akeneo_installer_check_reset_instance';
 
+    private Connection $connection;
+
     public function setUp(): void
     {
         parent::setUp();
+        $this->connection = $this->get('database_connection');
 
         $this->logAs('julia');
+        $this->featureFlags->enable('reset_pim');
     }
 
     public function test_it_returns_ok_when_no_job_is_queued_or_running(): void
@@ -24,12 +31,12 @@ class CheckInstanceCanBeResetActionTest extends ControllerIntegrationTestCase
         $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
 
         $response = $this->client->getResponse();
-        Assert::assertSame($response->getStatusCode(), Response::HTTP_OK);
+        Assert::assertSame($response->getStatusCode(), Response::HTTP_NO_CONTENT);
     }
 
     public function test_it_returns_failure_when_a_job_is_queued(): void
     {
-        //given a queued job execution queued
+        $this->given_a_job_with_status(BatchStatus::STARTING);
 
         $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
 
@@ -39,11 +46,26 @@ class CheckInstanceCanBeResetActionTest extends ControllerIntegrationTestCase
 
     public function test_it_returns_failure_when_a_job_is_running(): void
     {
-        //given a queued job execution running
+        $this->given_a_job_with_status(BatchStatus::STARTED);
 
         $this->webClientHelper->callApiRoute($this->client, self::ROUTE);
 
         $response = $this->client->getResponse();
         Assert::assertSame($response->getStatusCode(), Response::HTTP_BAD_REQUEST);
+    }
+
+    private function given_a_job_with_status(int $status): void
+    {
+        $jobInstanceId = $this->connection->executeQuery('SELECT id FROM akeneo_batch_job_instance WHERE code = "csv_product_quick_export";')->fetchOne();
+        $insertJobExecution = <<<SQL
+INSERT INTO `akeneo_batch_job_execution` (job_instance_id, pid, user, status, start_time, end_time, create_time, updated_time, health_check_time, exit_code, exit_description, failure_exceptions, log_file, raw_parameters)
+VALUES (:job_instance_id, null, 'admin', $status, null, null, '2020-10-16 09:38:16', null, null, 'UNKNOWN', '', 'a:0:{}', null, '{}');
+SQL;
+        $this->connection->executeUpdate($insertJobExecution, ['job_instance_id' => $jobInstanceId]);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 }

--- a/src/Akeneo/Platform/Installer/back/tests/Integration/ControllerIntegrationTestCase.php
+++ b/src/Akeneo/Platform/Installer/back/tests/Integration/ControllerIntegrationTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Installer\Test\Integration;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class ControllerIntegrationTestCase extends WebTestCase
+{
+    protected KernelBrowser $client;
+    protected WebClientHelper $webClientHelper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        static::bootKernel(['debug' => false]);
+
+        self::ensureKernelShutdown();
+        $this->client = static::createClient(['debug' => false]);
+        $this->client->disableReboot();
+        $this->webClientHelper = $this->get('akeneo_integration_tests.helper.web_client');
+    }
+
+    protected function get(string $service): ?object
+    {
+        return self::getContainer()->get($service);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        $this->ensureKernelShutdown();
+    }
+
+    protected function logAs(string $username): void
+    {
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn($username, $this->client);
+    }
+}

--- a/src/Akeneo/Platform/Installer/back/tests/Integration/ControllerIntegrationTestCase.php
+++ b/src/Akeneo/Platform/Installer/back/tests/Integration/ControllerIntegrationTestCase.php
@@ -4,22 +4,34 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Installer\Test\Integration;
 
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\FilePersistedFeatureFlags;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
+use Akeneo\Test\IntegrationTestsBundle\Helper\WebClientHelper;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class ControllerIntegrationTestCase extends WebTestCase
+abstract class ControllerIntegrationTestCase extends WebTestCase
 {
+    protected CatalogInterface $catalog;
     protected KernelBrowser $client;
     protected WebClientHelper $webClientHelper;
+    protected FilePersistedFeatureFlags $featureFlags;
 
     protected function setUp(): void
     {
         parent::setUp();
         static::bootKernel(['debug' => false]);
 
+        $this->catalog = $this->get('akeneo_integration_tests.catalogs');
+        $fixturesLoader = $this->get('akeneo_integration_tests.loader.fixtures_loader');
+        $fixturesLoader->load($this->getConfiguration());
+
         self::ensureKernelShutdown();
         $this->client = static::createClient(['debug' => false]);
         $this->client->disableReboot();
         $this->webClientHelper = $this->get('akeneo_integration_tests.helper.web_client');
+        $this->featureFlags = $this->get('feature_flags');
     }
 
     protected function get(string $service): ?object
@@ -39,4 +51,6 @@ class ControllerIntegrationTestCase extends WebTestCase
     {
         $this->get('akeneo_integration_tests.helper.authenticator')->logIn($username, $this->client);
     }
+
+    abstract protected function getConfiguration(): Configuration;
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -20,8 +20,12 @@ services:
         arguments:
             - '@database_connection'
 
-
     Akeneo\Platform\Job\Application\DeleteJobInstance\DeleteJobInstanceInterface:
         class: Akeneo\Platform\Job\Infrastructure\Query\DeleteJobInstance
         arguments:
             - '@database_connection'
+
+    Akeneo\Platform\Job\ServiceApi\JobExecution\FindQueuedAndRunningJobExecutionInterface:
+        class: Akeneo\Platform\Job\ServiceApi\JobExecution\FindQueuedAndRunningJobExecution
+        arguments:
+            - '@Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface'

--- a/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecution.php
@@ -11,7 +11,6 @@ use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionQuery;
  * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
  * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
 class FindQueuedAndRunningJobExecution implements FindQueuedAndRunningJobExecutionInterface
 {
     private const QUEUED_AND_RUNNING_STATUS = ['STARTING', 'IN_PROGRESS'];

--- a/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecution.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Job\ServiceApi\JobExecution;
+
+use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface;
+use Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionQuery;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+class FindQueuedAndRunningJobExecution implements FindQueuedAndRunningJobExecutionInterface
+{
+    private const QUEUED_AND_RUNNING_STATUS = ['STARTING', 'IN_PROGRESS'];
+
+    public function __construct(
+        private readonly SearchJobExecutionInterface $searchJobExecution,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count(int $size = 25): int
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = $size;
+        $query->status = self::QUEUED_AND_RUNNING_STATUS;
+
+        return $this->searchJobExecution->count($query);
+    }
+}

--- a/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecutionInterface.php
+++ b/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecutionInterface.php
@@ -8,7 +8,6 @@ namespace Akeneo\Platform\Job\ServiceApi\JobExecution;
  * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
  * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-
 interface FindQueuedAndRunningJobExecutionInterface
 {
     public function count(int $size): int;

--- a/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecutionInterface.php
+++ b/src/Akeneo/Platform/Job/back/ServiceApi/JobExecution/FindQueuedAndRunningJobExecutionInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Job\ServiceApi\JobExecution;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+interface FindQueuedAndRunningJobExecutionInterface
+{
+    public function count(int $size): int;
+}


### PR DESCRIPTION
- Add ServiceApi to count queued or running job execution (→ count method only for now, open to add a search method later on)
- Display error in message bar when trying to reset instance with queued or running jobs
