### PR TITLE
RAB-1407: Add main identifier in GetAttribute service api

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -53,6 +53,7 @@ SELECT attribute.code,
        attribute.decimals_allowed,
        attribute.backend_type,
        attribute.useable_as_grid_filter,
+       attribute.main_identifier,
        COALESCE(locale_codes, JSON_ARRAY()) AS available_locale_codes,
        translation.translations
 FROM pim_catalog_attribute attribute
@@ -86,6 +87,7 @@ SQL;
                 boolval($rawAttribute['decimals_allowed']),
                 $rawAttribute['backend_type'],
                 json_decode($rawAttribute['available_locale_codes']),
+                boolval($rawAttribute['main_identifier']),
                 boolval($rawAttribute['useable_as_grid_filter']),
                 $translations,
             );

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -87,9 +87,9 @@ SQL;
                 boolval($rawAttribute['decimals_allowed']),
                 $rawAttribute['backend_type'],
                 json_decode($rawAttribute['available_locale_codes']),
-                boolval($rawAttribute['main_identifier']),
                 boolval($rawAttribute['useable_as_grid_filter']),
                 $translations,
+                boolval($rawAttribute['main_identifier']),
             );
         }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -20,6 +20,7 @@ final class Attribute
         private ?bool $decimalsAllowed,
         private string $backendType,
         private array $availableLocaleCodes,
+        private readonly bool $mainIdentifier,
         private ?bool $useableAsGridFilter = null,
         private array $labels = [],
     ) {
@@ -94,5 +95,10 @@ final class Attribute
     public function labels(): array
     {
         return $this->labels;
+    }
+
+    public function isMainIdentifier(): bool
+    {
+        return $this->mainIdentifier;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -20,9 +20,9 @@ final class Attribute
         private ?bool $decimalsAllowed,
         private string $backendType,
         private array $availableLocaleCodes,
-        private readonly bool $mainIdentifier,
         private ?bool $useableAsGridFilter = null,
         private array $labels = [],
+        private readonly bool $mainIdentifier = false,
     ) {
     }
 

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -44,7 +44,8 @@ class InMemoryGetAttributes implements GetAttributes
                     $attribute->getDefaultMetricUnit(),
                     $attribute->isDecimalsAllowed(),
                     $attribute->getBackendType(),
-                    $attribute->getAvailableLocaleCodes()
+                    $attribute->getAvailableLocaleCodes(),
+                    $attribute->isMainIdentifier(),
                 );
             }
         }
@@ -62,6 +63,7 @@ class InMemoryGetAttributes implements GetAttributes
         $rawAttributes = $this->attributeRepository->findBy(['type' => $attributeType]);
         $attributes = [];
 
+        /** @var $attribute AttributeInterface*/
         foreach ($rawAttributes as $attribute) {
             $attributes[$attribute->getCode()] = new Attribute(
                 $attribute->getCode(),
@@ -73,7 +75,8 @@ class InMemoryGetAttributes implements GetAttributes
                 $attribute->getDefaultMetricUnit(),
                 $attribute->isDecimalsAllowed(),
                 $attribute->getBackendType(),
-                $attribute->getAvailableLocaleCodes()
+                $attribute->getAvailableLocaleCodes(),
+                $attribute->isMainIdentifier(),
             );
         }
 

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -45,7 +45,6 @@ class InMemoryGetAttributes implements GetAttributes
                     $attribute->isDecimalsAllowed(),
                     $attribute->getBackendType(),
                     $attribute->getAvailableLocaleCodes(),
-                    $attribute->isMainIdentifier(),
                 );
             }
         }
@@ -76,7 +75,6 @@ class InMemoryGetAttributes implements GetAttributes
                 $attribute->isDecimalsAllowed(),
                 $attribute->getBackendType(),
                 $attribute->getAvailableLocaleCodes(),
-                $attribute->isMainIdentifier(),
             );
         }
 

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
@@ -77,7 +77,7 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpectedByAttributeCodes();
         $query = $this->getQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
+        $actual = $query->forCodes(['sku', 'a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
@@ -85,7 +85,7 @@ final class SqlGetAttributesIntegration extends TestCase
     {
         $expected = $this->getExpectedByAttributeCodes();
         $query = $this->getCachedQuery();
-        $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
+        $actual = $query->forCodes(['sku', 'a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
@@ -96,9 +96,10 @@ final class SqlGetAttributesIntegration extends TestCase
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
-    public function getExpectedByAttributeCodes(): array
+    private function getExpectedByAttributeCodes(): array
     {
         return [
+            'sku' => new Attribute('sku', AttributeTypes::IDENTIFIER, ['reference_data_name' => null], false, false, null, null, false, 'text', [], true, ['en_US' => 'SKU'], true),
             'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
             'a_textarea' => new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, null, false, 'textarea', []),
             'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, null, false, 'boolean', [], null, ['en_US' => 'a boolean', 'fr_FR' => 'Un booléen']),
@@ -109,7 +110,7 @@ final class SqlGetAttributesIntegration extends TestCase
         ];
     }
 
-    public function getExpectedByType(): array
+    private function getExpectedByType(): array
     {
         return [
             'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
@@ -140,9 +141,9 @@ final class SqlGetAttributesIntegration extends TestCase
         $attributes = array_map(function (array $attributeData) {
             $attribute = $this->get('pim_catalog.factory.attribute')->create();
             $this->get('pim_catalog.updater.attribute')->update($attribute, $attributeData);
-            $constraintViolationss = $this->get('validator')->validate($attribute);
+            $constraintViolations = $this->get('validator')->validate($attribute);
 
-            Assert::count($constraintViolationss, 0);
+            Assert::count($constraintViolations, 0);
 
             return $attribute;
         }, $attributes);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR we added the ability to get the "main_identifier" property for GetAttribute service API

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
