### PR TITLE
PH-1104: :bug: Fix job_code empty in watchdog logs

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -108,6 +108,10 @@ final class JobExecutionWatchdogCommand extends Command
             );
         }
 
+        if (null === $jobCode) {
+            $jobCode = $this->executionManager->jobCodeFromJobExecutionId($jobExecutionId);
+        }
+
         $console = sprintf('%s/bin/console', $this->projectDir);
         $pathFinder = new PhpExecutableFinder();
         $startTime = time();


### PR DESCRIPTION
When the `job_execution_id` is provided to the watchdog, the `job_code` can be null

We must fetch it to have more explicit and usable logs