### PR TITLE
PH-1106: immediatly acknowledge schedules job messages

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\BatchQueueBundle\EventListener;
 
 use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessageInterface;
+use Akeneo\Tool\Component\BatchQueue\Queue\ScheduledJobMessageInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -38,7 +39,7 @@ final class AckMessageEventListener implements EventSubscriberInterface
     public function ackMessage(WorkerMessageReceivedEvent $event): void
     {
         $envelope = $event->getEnvelope();
-        if (!$envelope->getMessage() instanceof JobExecutionMessageInterface) {
+        if (!$envelope->getMessage() instanceof JobExecutionMessageInterface && !$envelope->getMessage() instanceof ScheduledJobMessageInterface) {
             return;
         }
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/EventListener/AckMessageEventListenerSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/EventListener/AckMessageEventListenerSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace spec\Akeneo\Tool\Bundle\BatchQueueBundle\EventListener;
 
 use Akeneo\Tool\Bundle\BatchQueueBundle\EventListener\AckMessageEventListener;
+use Akeneo\Tool\Component\BatchQueue\Queue\ScheduledJobMessage;
 use Akeneo\Tool\Component\BatchQueue\Queue\UiJobExecutionMessage;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -41,6 +42,19 @@ class AckMessageEventListenerSpec extends ObjectBehavior
         ReceiverInterface $receiver
     ) {
         $envelope = new Envelope(UiJobExecutionMessage::createJobExecutionMessage(1, []));
+        $event = new WorkerMessageReceivedEvent($envelope, 'receiver_name');
+
+        $receiverLocator->get('receiver_name')->shouldBeCalledOnce()->willReturn($receiver);
+        $receiver->ack($envelope)->shouldBeCalledOnce();
+
+        $this->ackMessage($event);
+    }
+
+    function it_acks_the_message_for_a_scheduled_message(
+        ContainerInterface $receiverLocator,
+        ReceiverInterface $receiver
+    ) {
+        $envelope = new Envelope(ScheduledJobMessage::createScheduledJobMessage("steven_job", []));
         $event = new WorkerMessageReceivedEvent($envelope, 'receiver_name');
 
         $receiverLocator->get('receiver_name')->shouldBeCalledOnce()->willReturn($receiver);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Scheduled jobs are not acknowledged immediately after consumption. It leads to multiple retries when a scheduled exceeds a duration of 10 minutes.
See https://github.com/akeneo/pim-community-dev/pull/14606/files

Unackownledged messages could probably be observed with [subscription/delivery_latency_health_score](https://cloud.google.com/monitoring/api/metrics_gcp#pubsub/subscription/delivery_latency_health_score)


**Definition Of Done (for Core Developer only)**

- [X] Tests
