### PR TITLE
JEL-358: Fix performance issue when running Symfony console

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Command/BenchmarkDumbCommand.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Command/BenchmarkDumbCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2023 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\MessengerBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Its goal is to be launched to perform benchmarks on Symfony console command execution time
+ *
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class BenchmarkDumbCommand extends Command
+{
+    protected static $defaultName = 'akeneo:messenger:benchmark-dumb';
+
+    protected function configure(): void
+    {
+        $this->setHidden(true);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return Command::SUCCESS;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/command.yml
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/command.yml
@@ -6,3 +6,7 @@ services:
             - '@logger'
         tags:
             - { name: console.command }
+
+    Akeneo\Tool\Bundle\MessengerBundle\Command\BenchmarkDumbCommand:
+        tags:
+            - { name: console.command }

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
@@ -42,12 +42,17 @@ services:
 
     Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry: ~
 
-    Akeneo\UserManagement\Infrastructure\Cli\EventListener\AuthenticateCommandAsAdminUserListener:
+    Akeneo\UserManagement\Infrastructure\Cli\AuthenticateAdminUser:
+        lazy: true
         arguments:
             - '@security.token_storage'
             - '@pim_user.repository.group'
             - '@pim_user.repository.role'
             - '@pim_user.factory.user'
+
+    Akeneo\UserManagement\Infrastructure\Cli\EventListener\AuthenticateCommandAsAdminUserListener:
+        arguments:
+            - '@Akeneo\UserManagement\Infrastructure\Cli\AuthenticateAdminUser'
             - '@Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry'
         tags:
             - { name: kernel.event_listener, event: console.command, method: createUserSystem }

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/AuthenticateAdminUser.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/AuthenticateAdminUser.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\UserManagement\Infrastructure\Cli;
+
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\UserManagement\Bundle\Security\SystemUserToken;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Doctrine\DBAL\Exception as DBALException;
+use Doctrine\Persistence\ObjectRepository;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * This service was initially a part of AuthenticateCommandAsAdminUserListener
+ * Its main purpose is to isolate the authentication details, to be able to make this service lazy
+ * So it will be instantiated only if needed (and so its dependencies)
+ */
+class AuthenticateAdminUser
+{
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly ObjectRepository $groupRepository,
+        private readonly ObjectRepository $roleRepository,
+        private readonly SimpleFactoryInterface $userFactory,
+    ) {
+    }
+
+    public function __invoke(): void
+    {
+        try {
+            $user = $this->userFactory->create();
+            $user->setUsername(UserInterface::SYSTEM_USER_NAME);
+
+            $groups = $this->groupRepository->findAll();
+            foreach ($groups as $group) {
+                $user->addGroup($group);
+            }
+
+            $roles = $this->roleRepository->findAll();
+            foreach ($roles as $role) {
+                $user->addRole($role);
+            }
+
+            $token = new SystemUserToken($user);
+            $this->tokenStorage->setToken($token);
+        } catch (DBALException $e) {
+            // do nothing.
+            // An exception can happen if db does not exist yet for instance
+        }
+    }
+}


### PR DESCRIPTION
To avoid performance issue, the services in dependency in `AuthenticateCommandAsAdminUserListener` need to be lazy (implemented only when called).
As it cannot be done directly with the DI attribute `lazy` for one of them, the process done in the listener are extracted in a dedicated lazy service.