### PR TITLE
PIM-11050: On "locale" DIV, missing the indication of the country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 - PIM-11040 : Sku is disabled according to the rights
 - PIM-11023 : Fix product search containing underscores
 - PIM-11016 : Improve the clean-removed-attributes command
+- PIM-11050 : On "locale" DIV, missing the indication of the country
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/locale-switcher.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/locale-switcher.html
@@ -1,13 +1,13 @@
 <a class="AknActionButton <% if (displayInline) { %> AknActionButton--big AknActionButton--noLeftBorder<% } else { %>AknActionButton--withoutBorder<% } %>" data-toggle="dropdown">
     <% if (!displayInline && displayLabel) { %><%- label %>: <% } %>
-    <span class="AknActionButton-highlight"><%= i18n.getFlag(currentLocale.code, false) %> <%- currentLocale.language %></span>
+    <span class="AknActionButton-highlight"><%= i18n.getFlag(currentLocale.code, false) %> <%- currentLocale.label %></span>
     <span class="AknActionButton-caret"></span>
 </a>
 <ul class="AknDropdown-menu">
     <div class="AknDropdown-menuTitle"><%- label %></div>
     <% _.each(locales, function (locale) { %>
         <li>
-            <span class="AknDropdown-menuLink<% if (currentLocale.code === locale.code) { %> AknDropdown-menuLink--active<% } %>" data-locale="<%- locale.code %>"><%= i18n.getFlag(locale.code, false) %> <%- locale.language %></span>
+            <span class="AknDropdown-menuLink<% if (currentLocale.code === locale.code) { %> AknDropdown-menuLink--active<% } %>" data-locale="<%- locale.code %>"><%= i18n.getFlag(locale.code, false) %> <%- locale.label %></span>
         </li>
     <% }); %>
 </ul>


### PR DESCRIPTION
On DQI locale filter the display was not the same on the other locale filter in the PIM
i fixed by changing the locale language to the locale label in the locale switcher template



**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
