### PR TITLE
PIM-11047: Fix $lazyRootCreation is not configurable for LocalFilesystemAdapter

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11047: Fix $lazyRootCreation is not configurable for LocalFilesystemAdapter
+
 # 7.0.17 (2023-05-24)
 
 # 7.0.16 (2023-05-24)

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -53,3 +53,5 @@ parameters:
     webhook_requests_limit: 4000
 
     openssl_config_path: '%pim_ce_dev_src_folder_location%/config/openssl.cnf'
+
+    local_storage_lazy_root_creation: false

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/Local/LocalStorageClientProvider.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/Local/LocalStorageClientProvider.php
@@ -27,7 +27,10 @@ final class LocalStorageClientProvider implements StorageClientProviderInterface
 
         $dirname = dirname($storage->getFilePath());
 
-        return new FileSystemStorageClient(new Filesystem(new LocalFilesystemAdapter($dirname)));
+        return new FileSystemStorageClient(new Filesystem(new LocalFilesystemAdapter(
+            location: $dirname,
+            lazyRootCreation: true,
+        )));
     }
 
     public function supports(StorageInterface $storage): bool

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/AkeneoFileStorageBundle.php
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/AkeneoFileStorageBundle.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Tool\Bundle\FileStorageBundle;
 
 use Akeneo\Tool\Bundle\FileStorageBundle\DependencyInjection\Compiler\ResolveDoctrineTargetModelPass;
+use Akeneo\Tool\Bundle\FileStorageBundle\DependencyInjection\Compiler\SetLazyRootCreationToLocalStorageAdapterPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -22,7 +23,8 @@ class AkeneoFileStorageBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container
-            ->addCompilerPass(new ResolveDoctrineTargetModelPass());
+            ->addCompilerPass(new ResolveDoctrineTargetModelPass())
+            ->addCompilerPass(new SetLazyRootCreationToLocalStorageAdapterPass());
 
         $mappings = [
             realpath(__DIR__.'/Resources/config/model/doctrine') => 'Akeneo\Tool\Component\FileStorage\Model',

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/DependencyInjection/Compiler/SetLazyRootCreationToLocalStorageAdapterPass.php
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/DependencyInjection/Compiler/SetLazyRootCreationToLocalStorageAdapterPass.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\FileStorageBundle\DependencyInjection\Compiler;
+
+use Behat\Behat\HelperContainer\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class SetLazyRootCreationToLocalStorageAdapterPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        try {
+            $definition = $container->getDefinition('oneup_flysystem.local_storage_adapter_adapter');
+            $lazyRootCreation = $container->getParameter('local_storage_lazy_root_creation') ?? false;
+            $definition->addArgument($lazyRootCreation);
+        } catch (ServiceNotFoundException) {
+        }
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**The issue**
A client who hosts the PIM without docker and with an `open_basedir` directive set on his PHP raised this [issue](https://github.com/akeneo/pim-community-dev/issues/19688). As his `open_basedir` directive makes the PIM fails due to the actual conf of our flysystem storage, he tried to customize the location but it makes the export/import fails.

**To reproduce**
- Create a `open_basedir.ini` file in `docker/build` with this content inside:
```ini
open_basedir="/srv/pim/:/tmp/:/usr/local/bin/:/var/www"
```
- Add these two lines in both `php` and `httpd` volumes sections in `docker-compose.yml`:
```yml
      - './docker/build/open_basedir.ini:/etc/php/8.1/fpm/conf.d/99-open_basedir.ini:ro'
      - './docker/build/open_basedir.ini:/etc/php/8.1/cli/conf.d/99-open_basedir.ini:ro'
```
- Run `make up` and try to run a command or access the PIM on a browser

**The solution** 
A solution is already implemented on flysystem side : setting up the `$lazyRootCreation` to true on the `LocalFilesystemAdapter`. Unfortunately, the Symfony bundle who's using to set up Flysystem in the DI does not support this option.
As the bundle loads his xml container config, we're not able to overrides the `oneup_flysystem.adapter.local` abstract service or the `LocalFactory`.
I submitted a [PR](https://github.com/1up-lab/OneupFlysystemBundle/pull/282) on the bundle repo to support it. Awaiting the approval, merge and release of a new version, I added a compiler pass which add the argument on the local storage service.

As this parameter is needed only when we run the PIM outside a container and with a PHP `open_basedir` directive. It is set to false by default in the PIM config and every user who need it can enable it in their pim standard installation.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
