### PR TITLE
GRF-845: add update category template command

### DIFF
--- a/src/Akeneo/Category/back/Application/Command/AddAttributeCommandHandler.php
+++ b/src/Akeneo/Category/back/Application/Command/AddAttributeCommandHandler.php
@@ -6,7 +6,7 @@ namespace Akeneo\Category\Application\Command;
 
 use Akeneo\Category\Application\Query\GetAttribute;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateAttributeSaver;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\Model\Attribute\Attribute;
 use Akeneo\Category\Domain\ValueObject\Attribute\AttributeAdditionalProperties;
 use Akeneo\Category\Domain\ValueObject\Attribute\AttributeCode;

--- a/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommand.php
+++ b/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\Application\Command\UpdateAttributeCommand;
 
+use Akeneo\Category\Domain\ValueObject\LabelCollection;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommand.php
+++ b/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\Application\Command\UpdateAttributeCommand;
 
-use Akeneo\Category\Domain\ValueObject\LabelCollection;
 use Webmozart\Assert\Assert;
 
 /**
@@ -16,21 +15,21 @@ use Webmozart\Assert\Assert;
 final class UpdateAttributeCommand
 {
     /**
-     * @param LocalizedLabels $labels
+     * @phpstan-param LocalizedLabels $labels
      */
     private function __construct(
         public readonly string $attributeUuid,
         public readonly ?bool $isRichTextArea,
         public readonly ?array $labels,
     ) {
-        Assert::uuid($attributeUuid);
-        if ($labels) {
-            LabelCollection::fromArray($this->labels);
+        if ($labels !== null) {
+            Assert::isMap($labels);
+            Assert::allNullOrString($labels);
         }
     }
 
     /**
-     * @param LocalizedLabels $labels
+     * @phpstan-param LocalizedLabels $labels
      */
     public static function create(
         string $attributeUuid,

--- a/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommandHandler.php
+++ b/src/Akeneo/Category/back/Application/Command/UpdateAttributeCommand/UpdateAttributeCommandHandler.php
@@ -6,7 +6,7 @@ namespace Akeneo\Category\Application\Command\UpdateAttributeCommand;
 
 use Akeneo\Category\Application\Query\GetAttribute;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateAttributeSaver;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\ValueObject\Attribute\AttributeUuid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 

--- a/src/Akeneo/Category/back/Application/Command/UpdateTemplateCommand/UpdateTemplateCommand.php
+++ b/src/Akeneo/Category/back/Application/Command/UpdateTemplateCommand/UpdateTemplateCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\Application\Command\UpdateTemplateCommand;
+
+use Symfony\Component\Validator\Constraints;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class UpdateTemplateCommand
+{
+    /**
+     * @var array<string,string|null>
+     */
+    #[Constraints\All([
+        new Constraints\Length(['max' => 255]),
+    ])]
+    public readonly array $labels;
+
+    /**
+     * @param array{labels:array<string,string|null>} $data
+     */
+    public function __construct(
+        public readonly string $templateUuid,
+        array $data,
+    ) {
+        Assert::keyExists($data, 'labels');
+        Assert::isMap($data['labels']);
+        Assert::allNullOrString($data['labels']);
+        $this->labels = $data['labels'];
+    }
+}

--- a/src/Akeneo/Category/back/Application/Command/UpdateTemplateCommand/UpdateTemplateCommandHandler.php
+++ b/src/Akeneo/Category/back/Application/Command/UpdateTemplateCommand/UpdateTemplateCommandHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\Application\Command\UpdateTemplateCommand;
+
+use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver;
+use Akeneo\Category\Domain\Exception\ViolationsException;
+use Akeneo\Category\Domain\Query\GetTemplate;
+use Akeneo\Category\Domain\ValueObject\LabelCollection;
+use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateTemplateCommandHandler
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        private readonly GetTemplate $getTemplate,
+        private readonly CategoryTemplateSaver $categoryTemplateSaver,
+    ) {
+    }
+
+    public function __invoke(UpdateTemplateCommand $command): void
+    {
+        $violations = $this->validator->validate($command);
+        if ($violations->count() > 0) {
+            throw new ViolationsException($violations);
+        }
+
+        $template = $this->getTemplate->byUuid(TemplateUuid::fromString($command->templateUuid));
+
+        $template->update(
+            labelCollection: LabelCollection::fromArray($command->labels),
+        );
+        $this->categoryTemplateSaver->update($template);
+    }
+}

--- a/src/Akeneo/Category/back/Application/UpsertCategoryCommandHandler.php
+++ b/src/Akeneo/Category/back/Application/UpsertCategoryCommandHandler.php
@@ -8,7 +8,7 @@ use Akeneo\Category\Api\Command\UpsertCategoryCommand;
 use Akeneo\Category\Application\Applier\UserIntentApplierRegistry;
 use Akeneo\Category\Application\Storage\Save\SaveCategory;
 use Akeneo\Category\Domain\Event\CategoryUpdatedEvent;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\Model\Enrichment\Category;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;
 use Akeneo\Category\Infrastructure\Registry\FindCategoryAdditionalPropertiesRegistry;

--- a/src/Akeneo/Category/back/Domain/Exception/TemplateNotFoundException.php
+++ b/src/Akeneo/Category/back/Domain/Exception/TemplateNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\Domain\Exception;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class TemplateNotFoundException extends \RuntimeException
+{
+}

--- a/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
+++ b/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
@@ -50,8 +50,6 @@ final class ViolationsException extends \LogicException
     }
 
     /**
-     * @deprecated
-     *
      * @return array<int, array{error: array{code: string|null, message: string}}>
      */
     public function normalizeDeprecated(): array

--- a/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
+++ b/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
@@ -28,6 +28,15 @@ final class ViolationsException extends \LogicException
     }
 
     /**
+     * Normalizes the constraint violation list recusively into an array based on the property path.
+     *
+     * For example, the property path "labels[en_US]" will be normalized into:
+     *  $errors = [
+     *      'labels' => [
+     *          'en_US' => ['An error message']
+     *      ]
+     *  ];
+     *
      * @return array<string, array<mixed>>
      */
     public function normalize(): array

--- a/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
+++ b/src/Akeneo/Category/back/Domain/Exception/ViolationsException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Category\Domain\Exceptions;
+namespace Akeneo\Category\Domain\Exception;
 
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -28,9 +28,33 @@ final class ViolationsException extends \LogicException
     }
 
     /**
-     * @return array<int, array{error: array{code: string|null, message: string}}>
+     * @return array<string, array<mixed>>
      */
     public function normalize(): array
+    {
+        if (count($this->constraintViolationList) === 0) {
+            return [];
+        }
+
+        $errors = [];
+        foreach ($this->constraintViolationList as $constraintViolation) {
+            $propertyPath = explode('[', str_replace(']', '', $constraintViolation->getPropertyPath()));
+            $current = &$errors;
+            foreach ($propertyPath as $property) {
+                $current = &$current[$property];
+            }
+            $current[] = $constraintViolation->getMessage();
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @deprecated
+     *
+     * @return array<int, array{error: array{code: string|null, message: string}}>
+     */
+    public function normalizeDeprecated(): array
     {
         if (count($this->constraintViolationList) === 0) {
             return [];

--- a/src/Akeneo/Category/back/Domain/Model/Attribute/Attribute.php
+++ b/src/Akeneo/Category/back/Domain/Model/Attribute/Attribute.php
@@ -185,7 +185,7 @@ abstract class Attribute
     }
 
     /**
-     * @param LocalizedLabels $labels
+     * @phpstan-param LocalizedLabels $labels
      */
     public function update(?bool $isRichTextArea, ?array $labels): void
     {
@@ -196,11 +196,7 @@ abstract class Attribute
         }
 
         if ($labels !== null) {
-            $labels = LabelCollection::fromArray($labels);
-
-            foreach ($labels->getIterator() as $local => $label) {
-                $this->labelCollection->setTranslation($local, $label);
-            }
+            $this->labelCollection->merge(LabelCollection::fromArray($labels));
         }
     }
 }

--- a/src/Akeneo/Category/back/Domain/Model/Enrichment/Template.php
+++ b/src/Akeneo/Category/back/Domain/Model/Enrichment/Template.php
@@ -55,6 +55,13 @@ class Template
         return $this->attributeCollection;
     }
 
+    public function update(?LabelCollection $labelCollection): void
+    {
+        if ($labelCollection !== null) {
+            $this->labelCollection->merge($labelCollection);
+        }
+    }
+
     /**
      * @return array{
      *     uuid: string,

--- a/src/Akeneo/Category/back/Domain/Query/GetTemplate.php
+++ b/src/Akeneo/Category/back/Domain/Query/GetTemplate.php
@@ -2,16 +2,20 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Category\Application\Query;
+namespace Akeneo\Category\Domain\Query;
 
+use Akeneo\Category\Domain\Exception\TemplateNotFoundException;
 use Akeneo\Category\Domain\Model\Enrichment\Template;
 use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
 
 /**
- * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 interface GetTemplate
 {
-    public function byUuid(TemplateUuid $uuid): ?Template;
+    /**
+     * @throws TemplateNotFoundException
+     */
+    public function byUuid(TemplateUuid $uuid): Template;
 }

--- a/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/GetTemplateController.php
+++ b/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/GetTemplateController.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Category\Infrastructure\Controller\InternalApi;
 
 use Akeneo\Category\Application\Query\GetAttribute;
-use Akeneo\Category\Application\Query\GetTemplate;
+use Akeneo\Category\Domain\Exception\TemplateNotFoundException;
+use Akeneo\Category\Domain\Query\GetTemplate;
 use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -35,8 +36,9 @@ class GetTemplateController
             throw new AccessDeniedException();
         }
 
-        $template = $this->getTemplate->byUuid(TemplateUuid::fromString($templateUuid));
-        if (null === $template) {
+        try {
+            $template = $this->getTemplate->byUuid(TemplateUuid::fromString($templateUuid));
+        } catch (TemplateNotFoundException $exception) {
             throw new NotFoundHttpException();
         }
 

--- a/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateAttributeController.php
+++ b/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateAttributeController.php
@@ -6,7 +6,7 @@ namespace Akeneo\Category\Infrastructure\Controller\InternalApi;
 
 use Akeneo\Category\Api\Command\CommandMessageBus;
 use Akeneo\Category\Application\Command\UpdateAttributeCommand\UpdateAttributeCommand;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -43,17 +43,8 @@ class UpdateAttributeController
                 labels: $data['labels'] ?? null,
             );
             $this->categoryCommandBus->dispatch($command);
-        } catch (ViolationsException $violationsException) {
-            $normalizedViolations = $violationsException->normalize();
-            foreach ($normalizedViolations as &$violation) {
-                $locale = $violation['error']['property'];
-                $regex = "/\[(.*?)\]/";
-                if (preg_match($regex, $locale, $matches)) {
-                    $violation['error']['property'] = $matches[1];
-                }
-            }
-
-            return new JsonResponse($normalizedViolations, Response::HTTP_BAD_REQUEST);
+        } catch (ViolationsException $exception) {
+            return new JsonResponse($exception->normalize(), Response::HTTP_BAD_REQUEST);
         }
 
         return new JsonResponse(null, Response::HTTP_OK);

--- a/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateCategoryController.php
+++ b/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateCategoryController.php
@@ -11,7 +11,7 @@ use Akeneo\Category\Application\Converter\StandardFormatToUserIntentsInterface;
 use Akeneo\Category\Application\Filter\CategoryEditAclFilter;
 use Akeneo\Category\Application\Filter\CategoryEditUserIntentFilter;
 use Akeneo\Category\Domain\Event\CategoryEditedEvent;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;
 use Akeneo\Category\Infrastructure\Converter\InternalApi\InternalApiToStd;
 use Akeneo\Category\Infrastructure\Registry\FindCategoryAdditionalPropertiesRegistry;
@@ -72,7 +72,7 @@ class UpdateCategoryController
             $this->categoryCommandBus->dispatch($command);
             $this->eventDispatcher->dispatch(new CategoryEditedEvent($category, $filteredUserIntents));
         } catch (ViolationsException $exception) {
-            return new JsonResponse($exception->normalize(), Response::HTTP_BAD_REQUEST);
+            return new JsonResponse($exception->normalizeDeprecated(), Response::HTTP_BAD_REQUEST);
         }
 
         $category = $this->getCategory->byId($category->getId()->getValue());

--- a/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateTemplateController.php
+++ b/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UpdateTemplateController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Category\Infrastructure\Controller\InternalApi;
 
 use Akeneo\Category\Api\Command\CommandMessageBus;
-use Akeneo\Category\Application\Command\AddAttributeCommand;
+use Akeneo\Category\Application\Command\UpdateTemplateCommand\UpdateTemplateCommand;
 use Akeneo\Category\Domain\Exception\ViolationsException;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AddAttributeController
+class UpdateTemplateController
 {
     public function __construct(
         private readonly SecurityFacade $securityFacade,
@@ -31,21 +31,11 @@ class AddAttributeController
             throw new AccessDeniedException();
         }
 
-        $data = $request->toArray();
-
         try {
-            $command = AddAttributeCommand::create(
-                code: $data['code'],
-                type: $data['type'],
-                isScopable: $data['is_scopable'],
-                isLocalizable: $data['is_localizable'],
-                templateUuid: $templateUuid,
-                locale: $data['locale'],
-                label: $data['label'],
-            );
+            $command = new UpdateTemplateCommand($templateUuid, $request->request->all());
             $this->categoryCommandBus->dispatch($command);
         } catch (ViolationsException $exception) {
-            return new JsonResponse($exception->normalizeDeprecated(), Response::HTTP_BAD_REQUEST);
+            return new JsonResponse($exception->normalize(), Response::HTTP_BAD_REQUEST);
         }
 
         return new JsonResponse(null, Response::HTTP_OK);

--- a/src/Akeneo/Category/back/Infrastructure/Storage/Save/Query/SqlCategoryTemplateSaver.php
+++ b/src/Akeneo/Category/back/Infrastructure/Storage/Save/Query/SqlCategoryTemplateSaver.php
@@ -51,6 +51,24 @@ class SqlCategoryTemplateSaver implements CategoryTemplateSaver
 
     public function update(Template $templateModel): void
     {
-        // TODO: Implement update() method.
+        $query = <<< SQL
+            UPDATE pim_catalog_category_template
+            SET
+                labels = :labels
+            WHERE uuid = UUID_TO_BIN(:uuid)
+            ;
+        SQL;
+
+        $this->connection->executeQuery(
+            $query,
+            [
+                'uuid' => (string) $templateModel->getUuid(),
+                'labels' => $templateModel->getLabelCollection()->normalize(),
+            ],
+            [
+                'uuid' => \PDO::PARAM_STR,
+                'labels' => Types::JSON,
+            ],
+        );
     }
 }

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -55,9 +55,8 @@ services:
         public: true
         arguments:
             - '@oro_security.security_facade'
-            - '@Akeneo\Category\Application\Query\GetTemplate'
+            - '@Akeneo\Category\Domain\Query\GetTemplate'
             - '@Akeneo\Category\Application\Query\GetAttribute'
-
 
     Akeneo\Category\Infrastructure\Controller\InternalApi\CreateTemplateController:
         public: true
@@ -65,6 +64,12 @@ services:
             - '@oro_security.security_facade'
             - '@Akeneo\Category\Domain\Query\GetCategoryInterface'
             - '@Akeneo\Category\Application\ActivateTemplate'
+
+    Akeneo\Category\Infrastructure\Controller\InternalApi\UpdateTemplateController:
+        public: true
+        arguments:
+            - '@oro_security.security_facade'
+            - '@category.command.message_bus'
 
     Akeneo\Category\Infrastructure\Controller\InternalApi\UploadController:
         public: true

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -56,6 +56,14 @@ services:
     tags:
       - { name: 'akeneo.category.command.handler', command: 'Akeneo\Category\Application\Command\UpdateAttributeCommand\UpdateAttributeCommand' }
 
+  Akeneo\Category\Application\Command\UpdateTemplateCommand\UpdateTemplateCommandHandler:
+    arguments:
+      - '@validator'
+      - '@Akeneo\Category\Domain\Query\GetTemplate'
+      - '@Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver'
+    tags:
+      - { name: 'akeneo.category.command.handler', command: 'Akeneo\Category\Application\Command\UpdateTemplateCommand\UpdateTemplateCommand' }
+
   Akeneo\Category\Application\Handler\StoreUploadedFile:
     arguments:
       - '@akeneo_file_storage.file_storage.file.file_storer'

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -23,7 +23,7 @@ services:
     arguments:
       - '@database_connection'
 
-  Akeneo\Category\Application\Query\GetTemplate:
+  Akeneo\Category\Domain\Query\GetTemplate:
     class: Akeneo\Category\Infrastructure\Storage\Sql\GetCategoryTemplateSql
     arguments:
       - '@database_connection'

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/routing/internal_api/category_template.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/routing/internal_api/category_template.yml
@@ -12,6 +12,12 @@ pim_category_template_rest_create:
         _feature: enriched_category
     methods: [POST]
 
+pim_category_template_rest_update:
+    path: /rest/{templateUuid}
+    defaults:
+        _controller: Akeneo\Category\Infrastructure\Controller\InternalApi\UpdateTemplateController
+    methods: [PATCH]
+
 pim_enriched_category_rest_deactivate_template:
     path: /rest/{templateUuid}
     defaults:

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -49,7 +49,7 @@ akeneo.category:
                 translations:
                     title: Label translations
                 error_message: There are invalid values on the page.
-                unsaved_changes: Those values will not be saved if you leave the page.
+                unsaved_changes: You have unsaved changes, are you sure that you want to leave?
         add_attribute:
             no_attribute_title: Create your first attribute
             no_attribute_instructions: Define the content you want to associate to your categories by adding Text, Text Area or Image attributes to this template.

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -2,6 +2,9 @@ pim_title:
     pim_category_template_edit: Edit category template
 
 akeneo.category:
+    unknown_error:
+        title: Sorry, an unknown error occurred.
+        message: Please reload the page and try again.
     tree_list:
         column:
             category_templates: Category templates

--- a/src/Akeneo/Category/back/tests/.php_cd.php
+++ b/src/Akeneo/Category/back/tests/.php_cd.php
@@ -16,7 +16,6 @@ $rules = [
         'Akeneo\Category\Domain',
 
         // TBD
-        'Akeneo\Category\Domain\Exceptions\ViolationsException',
         'Akeneo\Category\Api\Command\UpsertCategoryCommand',
         'Akeneo\Category\Api\Command\UserIntents\SetImage',
         'Akeneo\Category\Api\Command\UserIntents\SetLabel',

--- a/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateAttributeControllerEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateAttributeControllerEndToEnd.php
@@ -194,17 +194,15 @@ class UpdateAttributeControllerEndToEnd extends ControllerIntegrationTestCase
         $response = $this->client->getResponse();
         $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
 
+        $expectedErrors = [
+            'labels' => [
+                'fr_FR' => ['This value is too long. It should have 255 characters or less.'],
+                'en_US' => ['This value is too long. It should have 255 characters or less.'],
+            ]
+        ];
         $normalizedErrors = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        $this->assertCount(2, $normalizedErrors);
 
-        $localesList = ['fr_FR', 'en_US'];
-        foreach ($localesList as $locale) {
-            $localizedNormalizedError = array_values(array_filter($normalizedErrors, static function ($error) use ($locale) {
-                return $error['error']['property'] === $locale;
-            }));
-            $this->assertCount(1, $localizedNormalizedError);
-            $this->assertEquals('This value is too long. It should have 255 characters or less.', $localizedNormalizedError[0]['error']['message']);
-        }
+        $this->assertEquals($expectedErrors, $normalizedErrors);
     }
 
     public function testItDoesNotUpdateOnDeactivateTemplate(): void

--- a/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateAttributeControllerEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateAttributeControllerEndToEnd.php
@@ -198,7 +198,7 @@ class UpdateAttributeControllerEndToEnd extends ControllerIntegrationTestCase
             'labels' => [
                 'fr_FR' => ['This value is too long. It should have 255 characters or less.'],
                 'en_US' => ['This value is too long. It should have 255 characters or less.'],
-            ]
+            ],
         ];
         $normalizedErrors = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
 

--- a/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateTemplateControllerEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/InternalApi/UpdateTemplateControllerEndToEnd.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\back\tests\EndToEnd\InternalApi;
+
+use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver;
+use Akeneo\Category\Application\Storage\Save\Saver\CategoryTreeTemplateSaver;
+use Akeneo\Category\back\tests\EndToEnd\Helper\ControllerIntegrationTestCase;
+use Akeneo\Category\Domain\Model\Enrichment\Category;
+use Akeneo\Category\Domain\Model\Enrichment\Template;
+use Akeneo\Category\Domain\Query\GetCategoryInterface;
+use Akeneo\Category\Domain\Query\GetTemplate;
+use Akeneo\Category\Domain\ValueObject\LabelCollection;
+use Akeneo\Category\Domain\ValueObject\Template\TemplateCode;
+use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
+use Akeneo\Test\Integration\Configuration;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UpdateTemplateControllerEndToEnd extends ControllerIntegrationTestCase
+{
+    private GetCategoryInterface $getCategory;
+    private GetTemplate $getTemplate;
+    private CategoryTemplateSaver $categoryTemplateSaver;
+    private CategoryTreeTemplateSaver $categoryTreeTemplateSaver;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->getCategory = $this->get(GetCategoryInterface::class);
+        $this->getTemplate = $this->get(GetTemplate::class);
+        $this->categoryTemplateSaver = $this->get(CategoryTemplateSaver::class);
+        $this->categoryTreeTemplateSaver = $this->get(CategoryTreeTemplateSaver::class);
+    }
+
+    public function testItUpdatesTemplate(): void
+    {
+        // Given
+
+        $this->logAs('julia');
+        $template = $this->createTemplate();
+
+        // When
+
+        $data = [
+            'labels' => [
+                'en_US' => null,
+                'fr_FR' => '',
+                'es_ES' => 'Una plantilla',
+            ],
+        ];
+
+        $this->callApiRoute(
+            client: $this->client,
+            route: 'pim_category_template_rest_update',
+            routeArguments: ['templateUuid' => (string) $template->getUuid()],
+            method: Request::METHOD_PATCH,
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+        );
+
+        // Then
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $expectedLabels = [
+            'en_US' => null,
+            'fr_FR' => null,
+            'de_DE' => 'Eine Vorlage',
+            'es_ES' => 'Una plantilla',
+        ];
+
+        $updatedTemplate = $this->getTemplate->byUuid($template->getUuid());
+
+        $this->assertEquals($expectedLabels, $updatedTemplate->normalize()['labels']);
+    }
+
+    public function testItReturnsValidationErrors(): void
+    {
+        // Given
+
+        $this->logAs('julia');
+        $template = $this->createTemplate();
+
+        // When
+
+        $data = [
+            'labels' => [
+                'en_US' => 'A template',
+                'fr_FR' => <<<EOT
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce sed dictum diam. Aliquam auctor
+                    sodales lectus, at congue massa semper non. Nunc a mollis nibh. Suspendisse potenti. Donec quis
+                    lobortis justo, et consectetur turpis. Sed pulvinar lectus metus.
+                EOT,
+            ],
+        ];
+
+        $this->callApiRoute(
+            client: $this->client,
+            route: 'pim_category_template_rest_update',
+            routeArguments: ['templateUuid' => (string) $template->getUuid()],
+            method: Request::METHOD_PATCH,
+            content: json_encode($data, JSON_THROW_ON_ERROR),
+        );
+
+        // Then
+
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+
+        $expectedErrors = [
+            'labels' => [
+                'fr_FR' => ['This value is too long. It should have 255 characters or less.'],
+            ],
+        ];
+
+        $errors = json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertEquals($expectedErrors, $errors);
+    }
+
+    private function createTemplate(): Template
+    {
+        /** @var Category $category */
+        $category = $this->getCategory->byCode('master');
+
+        $templateUuid = TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330');
+        $template = new Template(
+            $templateUuid,
+            new TemplateCode('default_template'),
+            LabelCollection::fromArray([
+                'en_US' => 'A template',
+                'fr_FR' => 'Un template',
+                'de_DE' => 'Eine Vorlage',
+            ]),
+            $category->getId(),
+            null,
+        );
+
+        $this->categoryTemplateSaver->insert($template);
+        $this->categoryTreeTemplateSaver->insert($template);
+
+        return $template;
+    }
+}

--- a/src/Akeneo/Category/back/tests/Integration/Application/ActivateTemplateIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Application/ActivateTemplateIntegration.php
@@ -4,7 +4,7 @@ namespace Akeneo\Category\back\tests\Integration\Application;
 
 use Akeneo\Category\Application\ActivateTemplate;
 use Akeneo\Category\Application\Query\GetAttribute;
-use Akeneo\Category\Application\Query\GetTemplate;
+use Akeneo\Category\Domain\Query\GetTemplate;
 use Akeneo\Category\back\tests\Integration\Helper\CategoryTestCase;
 use Akeneo\Category\Domain\Model\Enrichment\Category;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Save/Query/SqlCategoryTemplateAttributeSaverIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Save/Query/SqlCategoryTemplateAttributeSaverIntegration.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Akeneo\Test\Category\Integration\Infrastructure\Storage\Save\Query;
 
 use Akeneo\Category\Application\Query\GetAttribute;
-use Akeneo\Category\Application\Query\GetTemplate;
+use Akeneo\Category\Domain\Query\GetTemplate;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateAttributeSaver;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTreeTemplateSaver;

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Save/Query/SqlCategoryTemplateSaverIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Save/Query/SqlCategoryTemplateSaverIntegration.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Akeneo\Test\Category\Integration\Infrastructure\Storage\Save\Query;
 
 use Akeneo\Category\Application\Query\GetAttribute;
-use Akeneo\Category\Application\Query\GetTemplate;
+use Akeneo\Category\Domain\Query\GetTemplate;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateAttributeSaver;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTreeTemplateSaver;
@@ -18,10 +18,15 @@ use Akeneo\Category\back\tests\Integration\Helper\CategoryTestCase;
 use Akeneo\Category\Domain\Model\Enrichment\Category;
 use Akeneo\Category\Domain\Model\Enrichment\Template;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;
+use Akeneo\Category\Domain\ValueObject\Attribute\AttributeCollection;
+use Akeneo\Category\Domain\ValueObject\CategoryId;
+use Akeneo\Category\Domain\ValueObject\LabelCollection;
+use Akeneo\Category\Domain\ValueObject\Template\TemplateCode;
+use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
 
 class SqlCategoryTemplateSaverIntegration extends CategoryTestCase
 {
-    public function testInsertNewCategoryTemplateInDatabase(): void
+    public function testInsertNewCategoryTemplate(): void
     {
         /** @var Category $category */
         $category = $this->get(GetCategoryInterface::class)->byCode('master');
@@ -43,5 +48,119 @@ class SqlCategoryTemplateSaverIntegration extends CategoryTestCase
 
         $this->assertEquals($templateModel->getCode(),$insertedTemplate->getCode());
         $this->assertEquals($templateModel->getLabelCollection(),$insertedTemplate->getLabelCollection());
+    }
+
+    public function testUpdatesCategoryTemplate(): void
+    {
+        /** @var Category $category */
+        $category = $this->get(GetCategoryInterface::class)->byCode('master');
+
+        // Given
+
+        $template = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('default_template'),
+            LabelCollection::fromArray(['en_US' => 'Default template', 'fr_FR' => 'Template par défaut']),
+            $category->getId(),
+            null,
+        );
+
+        $this->get(CategoryTemplateSaver::class)->insert($template);
+        $this->get(CategoryTreeTemplateSaver::class)->insert($template);
+
+        // When
+
+        $template = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('default_template'),
+            LabelCollection::fromArray(['en_US' => 'Default template']),
+            $category->getId(),
+            null,
+        );
+
+        $this->get(CategoryTemplateSaver::class)->update($template);
+
+        // Then
+
+        $expectedTemplate = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('default_template'),
+            LabelCollection::fromArray(['en_US' => 'Default template']),
+            $category->getId(),
+            AttributeCollection::fromArray([]),
+        );
+
+        /** @var Template $updatedTemplate */
+        $updatedTemplate = $this->get(GetTemplate::class)->byUuid($template->getUuid());
+
+        $this->assertEquals($expectedTemplate, $updatedTemplate);
+    }
+
+    public function testUpdatesCategoryTemplateDoesntUpdateReadonlyProperties(): void
+    {
+        /** @var Category $category */
+        $category = $this->get(GetCategoryInterface::class)->byCode('master');
+
+        // Given
+
+        $template = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('readonly_code'),
+            LabelCollection::fromArray([]),
+            $category->getId(),
+            null
+        );
+
+        $this->get(CategoryTemplateSaver::class)->insert($template);
+        $this->get(CategoryTreeTemplateSaver::class)->insert($template);
+
+        // When
+
+        $template = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('new_code'),
+            LabelCollection::fromArray([]),
+            new CategoryId(9999),
+            null,
+        );
+
+        $this->get(CategoryTemplateSaver::class)->update($template);
+
+        // Then
+
+        $expectedTemplate = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('readonly_code'),
+            LabelCollection::fromArray([]),
+            $category->getId(),
+            AttributeCollection::fromArray([])
+        );
+
+        /** @var Template $updatedTemplate */
+        $updatedTemplate = $this->get(GetTemplate::class)->byUuid($template->getUuid());
+
+        $this->assertEquals($expectedTemplate, $updatedTemplate);
+    }
+
+    public function testUpdatesCategoryTemplateIgnoreUnknownTemplate(): void
+    {
+        /** @var Category $category */
+        $category = $this->get(GetCategoryInterface::class)->byCode('master');
+
+        // When
+
+        $template = new Template(
+            TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
+            new TemplateCode('default_template'),
+            LabelCollection::fromArray(['en_US' => 'Default template']),
+            $category->getId(),
+            null,
+        );
+
+        $this->get(CategoryTemplateSaver::class)->update($template);
+
+        // Then
+
+        $this->doesNotPerformAssertions();
     }
 }

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Sql/GetCategoryTemplateSqlIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Sql/GetCategoryTemplateSqlIntegration.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\back\tests\Integration\Infrastructure\Storage\Sql;
 
-use Akeneo\Category\Application\Query\GetTemplate;
+use Akeneo\Category\Domain\Query\GetTemplate;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateSaver;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTreeTemplateSaver;
 use Akeneo\Category\back\tests\Integration\Helper\CategoryTestCase;
+use Akeneo\Category\Domain\Exception\TemplateNotFoundException;
 use Akeneo\Category\Domain\Model\Enrichment\Category;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;
 use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
@@ -48,9 +49,9 @@ class GetCategoryTemplateSqlIntegration extends CategoryTestCase
 
         $this->deactivateTemplate($templateUuid);
 
-        $retrievedTemplate = $this->get(GetTemplate::class)->byUuid(TemplateUuid::fromString($templateUuid));
+        $this->expectException(TemplateNotFoundException::class);
 
-        $this->assertNull($retrievedTemplate);
+        $this->get(GetTemplate::class)->byUuid(TemplateUuid::fromString($templateUuid));
     }
 
     protected function getConfiguration()

--- a/src/Akeneo/Category/back/tests/Specification/Application/Command/AddAttributeCommandHandlerSpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Application/Command/AddAttributeCommandHandlerSpec.php
@@ -8,7 +8,7 @@ use Akeneo\Category\Application\Command\AddAttributeCommand;
 use Akeneo\Category\Application\Command\AddAttributeCommandHandler;
 use Akeneo\Category\Application\Query\GetAttribute;
 use Akeneo\Category\Application\Storage\Save\Saver\CategoryTemplateAttributeSaver;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\ValueObject\Attribute\AttributeCollection;
 use Akeneo\Category\Domain\ValueObject\Template\TemplateUuid;
 use PhpSpec\ObjectBehavior;

--- a/src/Akeneo/Category/back/tests/Specification/Application/UpsertCategoryCommandHandlerSpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Application/UpsertCategoryCommandHandlerSpec.php
@@ -12,7 +12,7 @@ use Akeneo\Category\Application\Applier\UserIntentApplierRegistry;
 use Akeneo\Category\Application\Storage\Save\CategorySaverProcessor;
 use Akeneo\Category\Application\UpsertCategoryCommandHandler;
 use Akeneo\Category\Domain\Event\CategoryUpdatedEvent;
-use Akeneo\Category\Domain\Exceptions\ViolationsException;
+use Akeneo\Category\Domain\Exception\ViolationsException;
 use Akeneo\Category\Domain\Model\Enrichment\Category;
 use Akeneo\Category\Domain\Query\GetCategoryInterface;
 use Akeneo\Category\Domain\ValueObject\CategoryId;

--- a/src/Akeneo/Category/back/tests/Unit/Domain/Exception/ViolationsExceptionTest.php
+++ b/src/Akeneo/Category/back/tests/Unit/Domain/Exception/ViolationsExceptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\back\tests\Unit\Domain\Exception;
+
+use Akeneo\Category\Domain\Exception\ViolationsException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ViolationsExceptionTest extends TestCase
+{
+    public function testViolationsException(): void
+    {
+        $violationList = new ConstraintViolationList([
+            new ConstraintViolation('Error code 1', null, [], null, 'code', null),
+            new ConstraintViolation('Error code 2', null, [], null, 'code', null),
+            new ConstraintViolation('Error labels[en_US] 1', null, [], null, 'labels[en_US]', null),
+            new ConstraintViolation('Error labels[fr_FR] 1', null, [], null, 'labels[fr_FR]', null),
+            new ConstraintViolation('Error labels[fr_FR] 2', null, [], null, 'labels[fr_FR]', null),
+        ]);
+
+        $exception = new ViolationsException($violationList);
+
+        $this->assertEquals($violationList, $exception->violations());
+        $this->assertEquals([
+            'code' => ['Error code 1', 'Error code 2'],
+            'labels' => [
+                'en_US' => ['Error labels[en_US] 1'],
+                'fr_FR' => ['Error labels[fr_FR] 1', 'Error labels[fr_FR] 2'],
+            ],
+        ], $exception->normalize());
+    }
+}

--- a/src/Akeneo/Category/front/src/feature/CategoriesApp.tsx
+++ b/src/Akeneo/Category/front/src/feature/CategoriesApp.tsx
@@ -6,6 +6,10 @@ import {UnsavedChangesGuard} from './components/templates/UnsavedChangeGuard';
 import {SaveStatusProvider} from './components/providers/SaveStatusProvider';
 import {TemplateFormProvider} from './components/providers/TemplateFormProvider';
 import {CategoriesIndex, CategoriesTreePage, CategoryEditPage, TemplatePage} from './pages';
+import {BadRequestError} from './tools/apiFetch';
+import {ErrorBoundary} from './ErrorBoundary';
+
+const useErrorBoundary = (error: unknown) => false === error instanceof BadRequestError;
 
 type Props = {
   setCanLeavePage: (canLeavePage: boolean) => void;
@@ -13,36 +17,43 @@ type Props = {
 };
 
 const CategoriesApp: FC<Props> = ({setCanLeavePage, setLeavePageMessage}) => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {useErrorBoundary},
+      mutations: {useErrorBoundary},
+    },
+  });
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <CanLeavePageProvider setCanLeavePage={setCanLeavePage} setLeavePageMessage={setLeavePageMessage}>
-        <Router basename="/enrich/product-category-tree">
-          <Switch>
-            <Route path="/:treeId/tree">
-              <CategoriesTreePage />
-            </Route>
-            <Route path="/:categoryId/edit">
-              <EditCategoryProvider>
-                <CategoryEditPage />
-              </EditCategoryProvider>
-            </Route>
-            <Route path="/:treeId/template/:templateId">
-              <SaveStatusProvider>
-                <UnsavedChangesGuard />
-                <TemplateFormProvider>
-                  <TemplatePage />
-                </TemplateFormProvider>
-              </SaveStatusProvider>
-            </Route>
-            <Route path="/">
-              <CategoriesIndex />
-            </Route>
-          </Switch>
-        </Router>
-      </CanLeavePageProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <CanLeavePageProvider setCanLeavePage={setCanLeavePage} setLeavePageMessage={setLeavePageMessage}>
+          <Router basename="/enrich/product-category-tree">
+            <Switch>
+              <Route path="/:treeId/tree">
+                <CategoriesTreePage />
+              </Route>
+              <Route path="/:categoryId/edit">
+                <EditCategoryProvider>
+                  <CategoryEditPage />
+                </EditCategoryProvider>
+              </Route>
+              <Route path="/:treeId/template/:templateId">
+                <SaveStatusProvider>
+                  <UnsavedChangesGuard />
+                  <TemplateFormProvider>
+                    <TemplatePage />
+                  </TemplateFormProvider>
+                </SaveStatusProvider>
+              </Route>
+              <Route path="/">
+                <CategoriesIndex />
+              </Route>
+            </Switch>
+          </Router>
+        </CanLeavePageProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/Akeneo/Category/front/src/feature/ErrorBoundary.tsx
+++ b/src/Akeneo/Category/front/src/feature/ErrorBoundary.tsx
@@ -1,0 +1,21 @@
+import {Component} from 'react';
+import {ErrorPage} from './pages/ErrorPage';
+
+export class ErrorBoundary extends Component<unknown, {error?: Error}> {
+  constructor(props: unknown) {
+    super(props);
+    this.state = {};
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return {error};
+  }
+
+  render() {
+    if (this.state.error) {
+      return <ErrorPage error={this.state.error} />;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
@@ -56,6 +56,7 @@ export const AttributeLabelTranslationInput = ({attribute, localeCode, label}: P
         });
         handleStatusListChange(saveStatusId, Status.ERRORS);
       } else {
+        // Change status to "SAVED" to avoid the "unsaved changes" alert to be triggered during a reload of the page.
         handleStatusListChange(saveStatusId, Status.SAVED);
         throw error;
       }

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
@@ -56,6 +56,7 @@ export const AttributeLabelTranslationInput = ({attribute, localeCode, label}: P
         });
         handleStatusListChange(saveStatusId, Status.ERRORS);
       } else {
+        handleStatusListChange(saveStatusId, Status.SAVED);
         throw error;
       }
     }

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeLabelTranslationInput.tsx
@@ -6,6 +6,7 @@ import {Attribute} from '../../../models';
 import {useDebounceCallback} from '../../../tools/useDebounceCallback';
 import {Status} from '../../providers/SaveStatusProvider';
 import {useTemplateForm} from '../../providers/TemplateFormProvider';
+import {BadRequestError} from '../../../tools/apiFetch';
 
 const useFormData = (attribute: Attribute, localeCode: string) => {
   const [state] = useTemplateForm();
@@ -38,26 +39,26 @@ export const AttributeLabelTranslationInput = ({attribute, localeCode, label}: P
 
   const mutation = useUpdateTemplateAttribute(attribute.template_uuid, attribute.uuid);
   const debouncedUpdateAttributeLabel = useDebounceCallback(async (value: string) => {
-    handleStatusListChange(saveStatusId, Status.SAVING);
-    await mutation.mutateAsync(
-      {labels: {[localeCode]: value}},
-      {
-        onError: error => {
-          const errors = error.data.map(({error}) => error.message);
-          dispatch({
-            type: 'save_attribute_label_translation_failed',
-            payload: {attributeUuid: attribute.uuid, localeCode, errors},
-          });
-          handleStatusListChange(saveStatusId, Status.ERRORS);
-        },
+    try {
+      handleStatusListChange(saveStatusId, Status.SAVING);
+      await mutation.mutateAsync({labels: {[localeCode]: value}});
+      await queryClient.invalidateQueries(['get-template', attribute.template_uuid]);
+      dispatch({
+        type: 'attribute_label_translation_saved',
+        payload: {attributeUuid: attribute.uuid, localeCode, value},
+      });
+      handleStatusListChange(saveStatusId, Status.SAVED);
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        dispatch({
+          type: 'save_attribute_label_translation_failed',
+          payload: {attributeUuid: attribute.uuid, localeCode, errors: error.data.labels[localeCode]},
+        });
+        handleStatusListChange(saveStatusId, Status.ERRORS);
+      } else {
+        throw error;
       }
-    );
-    await queryClient.invalidateQueries(['get-template', attribute.template_uuid]);
-    dispatch({
-      type: 'attribute_label_translation_saved',
-      payload: {attributeUuid: attribute.uuid, localeCode, value},
-    });
-    handleStatusListChange(saveStatusId, Status.SAVED);
+    }
   }, 300);
 
   const handleTranslationChange = async (value: string) => {

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeSettings.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm/AttributeSettings.tsx
@@ -1,7 +1,7 @@
 import {useTranslate, userContext} from '@akeneo-pim-community/shared';
 import {Button, Checkbox, SectionTitle, useBooleanState} from 'akeneo-design-system';
 import styled from 'styled-components';
-import {useCatalogActivatedLocales} from '../../../hooks/useCatalogActivatedLocales';
+import {useCatalogActivatedLocaleCodes} from '../../../hooks/useCatalogActivatedLocaleCodes';
 import {useCatalogLocales} from '../../../hooks/useCatalogLocales';
 import {Attribute} from '../../../models';
 import {getLabelFromAttribute} from '../../attributes';
@@ -17,8 +17,13 @@ export const AttributeSettings = ({attribute}: Props) => {
   const translate = useTranslate();
   const attributeLabel = getLabelFromAttribute(attribute, userContext.get('catalogLocale'));
 
-  const activatedCatalogLocales = useCatalogActivatedLocales();
   const catalogLocales = useCatalogLocales();
+  const activatedCatalogLocaleCodes = useCatalogActivatedLocaleCodes();
+  const sortedActivatedCatalogLocales = activatedCatalogLocaleCodes
+    ?.map(
+      localeCode => catalogLocales?.find(locale => locale.code === localeCode) || {code: localeCode, label: localeCode}
+    )
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   const [
     isDeactivateTemplateAttributeModalOpen,
@@ -55,12 +60,12 @@ export const AttributeSettings = ({attribute}: Props) => {
         </SectionTitle.Title>
       </SectionTitle>
       <FieldContainer>
-        {activatedCatalogLocales?.map(localeCode => (
+        {sortedActivatedCatalogLocales?.map(locale => (
           <AttributeLabelTranslationInput
-            key={localeCode}
+            key={locale.code}
             attribute={attribute}
-            localeCode={localeCode}
-            label={catalogLocales?.find(catalogLocale => catalogLocale.code === localeCode)?.label || localeCode}
+            localeCode={locale.code}
+            label={locale.label}
           />
         ))}
       </FieldContainer>

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/EditTemplatePropertiesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/EditTemplatePropertiesForm.tsx
@@ -13,6 +13,7 @@ export const EditTemplatePropertiesForm = ({template}: Props) => {
   const translate = useTranslate();
 
   const uiLocales = useUiLocales();
+  const sortedUiLocales = uiLocales?.sort((a, b) => a.label.localeCompare(b.label));
 
   return (
     <>
@@ -25,23 +26,18 @@ export const EditTemplatePropertiesForm = ({template}: Props) => {
         </Field>
       </FieldContainer>
 
-      {
-        uiLocales && (
-            <>
-              <SectionTitle>
-                <SectionTitle.Title>
-                  {translate('akeneo.category.template.properties.label_translations_in_ui_locales')}
-                </SectionTitle.Title>
-              </SectionTitle>
-              <FieldContainer>
-                {uiLocales.map(locale => (
-                  <TemplateLabelTranslationInput key={locale.code} locale={locale} template={template} />
-                ))}
-              </FieldContainer>
-            </>
-          ) &&
-          null /* remove to display section */
-      }
+      <>
+        <SectionTitle>
+          <SectionTitle.Title>
+            {translate('akeneo.category.template.properties.label_translations_in_ui_locales')}
+          </SectionTitle.Title>
+        </SectionTitle>
+        <FieldContainer>
+          {sortedUiLocales?.map(locale => (
+            <TemplateLabelTranslationInput key={locale.code} locale={locale} template={template} />
+          ))}
+        </FieldContainer>
+      </>
     </>
   );
 };

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
@@ -58,6 +58,7 @@ export const TemplateLabelTranslationInput = ({template, locale}: Props) => {
         });
         handleStatusListChange(saveStatusId, Status.ERRORS);
       } else {
+        // Change status to "SAVED" to avoid the "unsaved changes" alert to be triggered during a reload of the page.
         handleStatusListChange(saveStatusId, Status.SAVED);
         throw error;
       }

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
@@ -58,6 +58,7 @@ export const TemplateLabelTranslationInput = ({template, locale}: Props) => {
         });
         handleStatusListChange(saveStatusId, Status.ERRORS);
       } else {
+        handleStatusListChange(saveStatusId, Status.SAVED);
         throw error;
       }
     }

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplatePropertiesForm/TemplateLabelTranslationInput.tsx
@@ -1,27 +1,12 @@
 import {Field, Helper, TextInput} from 'akeneo-design-system';
-import {useMutation, useQueryClient} from 'react-query';
+import {useQueryClient} from 'react-query';
 import {useSaveStatus} from '../../../hooks/useSaveStatus';
+import {useUpdateTemplateProperties} from '../../../hooks/useUpdateTemplateProperties';
 import {Template} from '../../../models';
-import {useTemplateForm} from '../../providers/TemplateFormProvider';
+import {BadRequestError} from '../../../tools/apiFetch';
 import {useDebounceCallback} from '../../../tools/useDebounceCallback';
 import {Status} from '../../providers/SaveStatusProvider';
-import {BadRequestError} from '../../../tools/apiFetch';
-
-// Temporary, awaiting the implementation of the API endpoint
-const useUpdateTemplateProperties = (templateUuid: string) => {
-  return useMutation<
-    void,
-    BadRequestError<
-      Array<{
-        error: {
-          property: string;
-          message: string;
-        };
-      }>
-    >,
-    {labels: {[localeCode: string]: string}}
-  >(() => new Promise<void>(resolve => setTimeout(resolve, 150)));
-};
+import {useTemplateForm} from '../../providers/TemplateFormProvider';
 
 const useFormData = (template: Template, localeCode: string) => {
   const [state] = useTemplateForm();
@@ -56,26 +41,26 @@ export const TemplateLabelTranslationInput = ({template, locale}: Props) => {
 
   const mutation = useUpdateTemplateProperties(template.uuid);
   const debouncedUpdateTemplateLabel = useDebounceCallback(async (value: string) => {
-    handleStatusListChange(saveStatusId, Status.SAVING);
-    await mutation.mutateAsync(
-      {labels: {[locale.code]: value}},
-      {
-        onError: error => {
-          const errors = error.data.map(({error}) => error.message);
-          dispatch({
-            type: 'save_template_label_translation_failed',
-            payload: {localeCode: locale.code, errors},
-          });
-          handleStatusListChange(saveStatusId, Status.ERRORS);
-        },
+    try {
+      handleStatusListChange(saveStatusId, Status.SAVING);
+      await mutation.mutateAsync({labels: {[locale.code]: value}});
+      await queryClient.invalidateQueries(['get-template', template.uuid]);
+      dispatch({
+        type: 'template_label_translation_saved',
+        payload: {localeCode: locale.code, value},
+      });
+      handleStatusListChange(saveStatusId, Status.SAVED);
+    } catch (error) {
+      if (error instanceof BadRequestError) {
+        dispatch({
+          type: 'save_template_label_translation_failed',
+          payload: {localeCode: locale.code, errors: error.data.labels[locale.code]},
+        });
+        handleStatusListChange(saveStatusId, Status.ERRORS);
+      } else {
+        throw error;
       }
-    );
-    await queryClient.invalidateQueries(['get-template', template.uuid]);
-    dispatch({
-      type: 'template_label_translation_saved',
-      payload: {localeCode: locale.code, value},
-    });
-    handleStatusListChange(saveStatusId, Status.SAVED);
+    }
   }, 300);
 
   const handleChange = async (value: string) => {

--- a/src/Akeneo/Category/front/src/feature/hooks/useCatalogActivatedLocaleCodes.ts
+++ b/src/Akeneo/Category/front/src/feature/hooks/useCatalogActivatedLocaleCodes.ts
@@ -3,7 +3,7 @@ import {useCallback} from 'react';
 import {apiFetch} from '../tools/apiFetch';
 import {useQuery} from 'react-query';
 
-const useCatalogActivatedLocales = () => {
+export const useCatalogActivatedLocaleCodes = () => {
   const url = useRoute('internal_api_category_catalog_activated_locales', {});
 
   const fetchCatalogLocales = useCallback(async () => {
@@ -13,4 +13,3 @@ const useCatalogActivatedLocales = () => {
   const {data} = useQuery<string[]>(['get-catalog-activated-locales'], fetchCatalogLocales, {});
   return data;
 };
-export {useCatalogActivatedLocales};

--- a/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateAttribute.ts
+++ b/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateAttribute.ts
@@ -1,17 +1,14 @@
 import {useRoute} from '@akeneo-pim-community/shared';
 import {useMutation} from 'react-query';
-import {BadRequestError, apiFetch} from '../tools/apiFetch';
+import {ApiError, apiFetch} from '../tools/apiFetch';
 
-type ResponseError = {
-  error: {
-    property: string;
-    message: string;
-  };
-};
-
-type Body = {
+type Data = {
   isRichTextArea?: boolean;
   labels?: {[locale: string]: string};
+};
+
+type Error = {
+  labels: {[localeCode: string]: string[]};
 };
 
 export const useUpdateTemplateAttribute = (templateUuid: string, attributeUuid: string) => {
@@ -20,10 +17,10 @@ export const useUpdateTemplateAttribute = (templateUuid: string, attributeUuid: 
     attributeUuid: attributeUuid,
   });
 
-  return useMutation<void, BadRequestError<ResponseError[]>, Body>(body =>
+  return useMutation<void, ApiError<Error>, Data>(data =>
     apiFetch(url, {
       method: 'POST',
-      body: JSON.stringify(body),
+      body: JSON.stringify(data),
     })
   );
 };

--- a/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateProperties.ts
+++ b/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateProperties.ts
@@ -1,13 +1,13 @@
 import {useRoute} from '@akeneo-pim-community/shared';
 import {useMutation} from 'react-query';
-import {BadRequestError, apiFetch} from '../tools/apiFetch';
+import {ApiError, apiFetch} from '../tools/apiFetch';
+
+type Data = {labels: {[localeCode: string]: string}};
+
+type Error = ApiError<{labels: {[localeCode: string]: string[]}}>;
 
 export const useUpdateTemplateProperties = (templateUuid: string) => {
   const url = useRoute('pim_category_template_rest_update', {templateUuid});
 
-  return useMutation<
-    void,
-    BadRequestError<{labels: {[localeCode: string]: string[]}}>,
-    {labels: {[localeCode: string]: string}}
-  >(data => apiFetch(url, {method: 'PATCH', body: JSON.stringify(data)}));
+  return useMutation<void, Error, Data>(data => apiFetch(url, {method: 'PATCH', body: JSON.stringify(data)}));
 };

--- a/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateProperties.ts
+++ b/src/Akeneo/Category/front/src/feature/hooks/useUpdateTemplateProperties.ts
@@ -1,0 +1,13 @@
+import {useRoute} from '@akeneo-pim-community/shared';
+import {useMutation} from 'react-query';
+import {BadRequestError, apiFetch} from '../tools/apiFetch';
+
+export const useUpdateTemplateProperties = (templateUuid: string) => {
+  const url = useRoute('pim_category_template_rest_update', {templateUuid});
+
+  return useMutation<
+    void,
+    BadRequestError<{labels: {[localeCode: string]: string[]}}>,
+    {labels: {[localeCode: string]: string}}
+  >(data => apiFetch(url, {method: 'PATCH', body: JSON.stringify(data)}));
+};

--- a/src/Akeneo/Category/front/src/feature/pages/ErrorPage.tsx
+++ b/src/Akeneo/Category/front/src/feature/pages/ErrorPage.tsx
@@ -1,0 +1,41 @@
+import {PageContent, PageHeader, useTranslate} from '@akeneo-pim-community/shared';
+import {ClientErrorIllustration, Placeholder} from 'akeneo-design-system';
+import {useEffect} from 'react';
+import {ForbiddenError, UnauthorizedError} from '../tools/apiFetch';
+
+type Props = {
+  error: unknown;
+};
+
+export const ErrorPage = ({error}: Props) => {
+  const translate = useTranslate();
+
+  useEffect(() => {
+    // Reload to force the user to log in again
+    if (error instanceof UnauthorizedError) {
+      globalThis.location.reload();
+      return;
+    }
+
+    // Reload to force the refresh of the user's permissions
+    if (error instanceof ForbiddenError) {
+      globalThis.location.reload();
+      return;
+    }
+  }, [error]);
+
+  return (
+    <>
+      <PageHeader />
+      <PageContent>
+        <Placeholder
+          illustration={<ClientErrorIllustration />}
+          size="large"
+          title={translate('akeneo.category.unknown_error.title')}
+        >
+          {translate('akeneo.category.unknown_error.message')}
+        </Placeholder>
+      </PageContent>
+    </>
+  );
+};

--- a/src/Akeneo/Category/front/src/feature/tools/apiFetch.ts
+++ b/src/Akeneo/Category/front/src/feature/tools/apiFetch.ts
@@ -1,10 +1,25 @@
 export class BadRequestError<T> extends Error {
   constructor(public readonly data: T) {
     super();
+    Object.setPrototypeOf(this, BadRequestError.prototype);
   }
 }
 
-export class ForbiddenError extends Error {}
+export class ForbiddenError extends Error {
+  constructor() {
+    super();
+    Object.setPrototypeOf(this, ForbiddenError.prototype);
+  }
+}
+
+export class UnauthorizedError extends Error {
+  constructor() {
+    super();
+    Object.setPrototypeOf(this, UnauthorizedError.prototype);
+  }
+}
+
+export type ApiError<T> = BadRequestError<T> | UnauthorizedError | ForbiddenError | Error;
 
 export const apiFetch = async <T = void, E = unknown>(url: string, init: RequestInit): Promise<T> => {
   const response = await fetch(url, {
@@ -21,6 +36,8 @@ export const apiFetch = async <T = void, E = unknown>(url: string, init: Request
       case 400:
       case 422:
         throw new BadRequestError<E>(await response.json());
+      case 401:
+        throw new UnauthorizedError();
       case 403:
         throw new ForbiddenError();
       default:


### PR DESCRIPTION
- Added UpdateTemplateCommand & endpoint
- Enabled edit template properties form on the frontend
- Added error boundary to handle errors
  - 401/403 HTTP errors reload the page
  - Other error display an error page
 
![localhost_8080_](https://github.com/akeneo/pim-community-dev/assets/1671213/57bfd75d-45fb-44ca-8ce5-4a6cdf55c815)

