### PR TITLE
CPM-1074: Add is_main_identifier on get attributes search params

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
@@ -123,6 +123,12 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
                     case '>':
                         $qb->andWhere($qb->expr()->gt($field, $parameter));
                         break;
+                    case '=':
+                        if ('is_main_identifier' !== $property) {
+                            throw new \InvalidArgumentException('Invalid operator for search query.');
+                        }
+                        $qb->andWhere($qb->expr()->eq('r.mainIdentifier', $parameter));
+                        break;
                     default:
                         throw new \InvalidArgumentException('Invalid operator for search query.');
                 }
@@ -183,6 +189,20 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
                     ],
                 ])
             ),
+            'is_main_identifier' => new Assert\All([
+                new Assert\Collection([
+                    'operator' => new Assert\IdenticalTo([
+                        'value' => '=',
+                        'message' => 'In order to search on attribute is_main_identifier you must use "=" operator, {{ value }} given.',
+                    ]),
+                    'value' => [
+                        new Assert\Type([
+                            'type' => 'bool',
+                            'message' => 'The "is_main_identifier" filter requires a boolean value, and the submitted value is not.',
+                        ]),
+                    ],
+                ]),
+            ]),
         ];
         $availableSearchFilters = array_keys($constraints);
 

--- a/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/ListAttributeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/ListAttributeEndToEnd.php
@@ -316,6 +316,41 @@ JSON;
         $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
     }
 
+    public function testAttributeSearchByMainIdentifier()
+    {
+        $client = $this->createAuthenticatedClient();
+        $search = '{"is_main_identifier":[{"operator":"=","value":true}]}';
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+
+        $client->request('GET', 'api/rest/v1/attributes?limit=5&page=1&with_count=true&search=' . $search);
+
+        $standardizedAttributes = $this->getStandardizedAttributes();
+
+        $expected = <<<JSON
+{
+	"_links": {
+		"self": {
+			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=5&with_count=true&search={$searchEncoded}"
+		},
+		"first": {
+			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=5&with_count=true&search={$searchEncoded}"
+		}
+	},
+	"current_page": 1,
+	"items_count": 1,
+    "_embedded" : {
+        "items" : [
+            {$standardizedAttributes['sku']}
+        ]
+    }
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
     public function testOutOfRangeListAttributes()
     {
         $client = $this->createAuthenticatedClient();
@@ -388,6 +423,47 @@ JSON;
      */
     protected function getStandardizedAttributes()
     {
+        $standardizedAttributes['sku'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/attributes/sku"
+        }
+    },
+    "code": "sku",
+    "type": "pim_catalog_identifier",
+    "group": "attributeGroupA",
+    "unique": true,
+    "useable_as_grid_filter": true,
+    "allowed_extensions": [],
+    "metric_family": null,
+    "default_metric_unit": null,
+    "reference_data_name": null,
+    "available_locales": [],
+    "max_characters": null,
+    "validation_rule": null,
+    "validation_regexp": null,
+    "wysiwyg_enabled": null,
+    "number_min": null,
+    "number_max": null,
+    "decimals_allowed": null,
+    "negative_allowed": null,
+    "date_min": null,
+    "date_max": null,
+    "max_file_size": null,
+    "minimum_input_length": null,
+    "sort_order": 0,
+    "localizable": false,
+    "scopable": false,
+    "labels": {},
+    "guidelines": {"en_US": "this is the sku"},
+    "auto_option_sorting": null,
+    "default_value": null,
+    "group_labels"           : {"en_US": "Attribute group A","fr_FR": "Groupe d'attribut A"},
+    "is_main_identifier": true
+}
+JSON;
+
         $standardizedAttributes['a_date'] = <<<JSON
 {
     "_links": {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add `is_main_identifier` in search params for getAttributes API endpoint


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
