### PR TITLE
PIM-11039: Fix export with duplicated labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - PIM-11023 : Fix product search containing underscores
 - PIM-11016 : Improve the clean-removed-attributes command
 - PIM-11050 : On "locale" DIV, missing the indication of the country
+- PIM-11039: Fix export with duplicated labels
 - PIM-10869: Image upload fields now only accept images
 
 ## Improvements

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/TranslatedColumnPresenter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/TranslatedColumnPresenter.php
@@ -11,6 +11,7 @@ class TranslatedColumnPresenter implements ColumnPresenterInterface
 {
     public function present(array $columns, array $context): array
     {
+        $columns = \array_combine($columns, $columns);
         if (!$this->headerAreTranslated($context)) {
             return $columns;
         }
@@ -40,7 +41,7 @@ class TranslatedColumnPresenter implements ColumnPresenterInterface
     private function removeCodeWhenTranslationIsNotDuplicated(array $columns, array $duplicatedTranslations): array
     {
         return array_map(function (string $column) use ($duplicatedTranslations) {
-            list($code, $columnTranslation) = explode(
+            [$code, $columnTranslation] = explode(
                 FlatTranslatorInterface::COLUMN_CODE_AND_TRANSLATION_SEPARATOR,
                 $column,
                 2

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
@@ -84,22 +84,21 @@ class FlatItemBufferFlusher implements StepExecutionAwareInterface
         $headers = $this->sortHeaders($buffer->getHeaders());
         $headers = $this->columnPresenter->present($headers, $this->stepExecution->getJobParameters()->all());
 
-        $hollowItem = array_fill_keys($headers, '');
-
         $writer = $this->getWriter($filePath, $writerOptions);
         if ([] !== $headers) {
             $writer->addRow(Row::fromValues($headers));
         }
 
         foreach ($buffer as $incompleteItem) {
-            $incompleteKeys = $this->columnPresenter->present(
-                array_keys($incompleteItem),
-                $this->stepExecution->getJobParameters()->all()
-            );
+            $item = array_fill_keys($headers, '');
+            foreach ($incompleteItem as $key => $value) {
+                $headerName = $headers[$key] ?? null;
+                if (null === $headerName) {
+                    continue;
+                }
+                $item[$headerName] = $value;
+            }
 
-            $incompleteItem = array_combine($incompleteKeys, $incompleteItem);
-
-            $item = array_replace($hollowItem, $incompleteItem);
             $writer->addRow(Row::fromValues($item));
 
             if (null !== $this->stepExecution) {
@@ -135,7 +134,6 @@ class FlatItemBufferFlusher implements StepExecutionAwareInterface
         $headers = $this->sortHeaders($buffer->getHeaders());
         $headers = $this->columnPresenter->present($headers, $this->stepExecution->getJobParameters()->all());
 
-        $hollowItem = array_fill_keys($headers, '');
         $writer = null;
         $filePath = '';
         foreach ($buffer as $count => $incompleteItem) {
@@ -153,14 +151,14 @@ class FlatItemBufferFlusher implements StepExecutionAwareInterface
                 }
             }
 
-            $incompleteKeys = $this->columnPresenter->present(
-                array_keys($incompleteItem),
-                $this->stepExecution->getJobParameters()->all()
-            );
-
-            $incompleteItem = array_combine($incompleteKeys, $incompleteItem);
-
-            $item = array_replace($hollowItem, $incompleteItem);
+            $item = array_fill_keys($headers, '');
+            foreach ($incompleteItem as $key => $value) {
+                $headerName = $headers[$key] ?? null;
+                if (null === $headerName) {
+                    continue;
+                }
+                $item[$headerName] = $value;
+            }
             $writer->addRow(Row::fromValues($item));
             $writtenLinesCount++;
 

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/SimpleColumnPresenter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/SimpleColumnPresenter.php
@@ -8,6 +8,6 @@ class SimpleColumnPresenter implements ColumnPresenterInterface
 {
     public function present(array $data, array $context): array
     {
-        return $data;
+        return \array_combine($data, $data);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/TranslatedColumnPresenterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/TranslatedColumnPresenterSpec.php
@@ -6,35 +6,40 @@ use PhpSpec\ObjectBehavior;
 
 class TranslatedColumnPresenterSpec extends ObjectBehavior
 {
-    function it_only_handle_export_with_translated_header()
+    function it_only_handles_export_with_translated_header()
     {
         $data = [
             'sku--[sku]',
             'description--Description',
             'name--Nom',
         ];
+        $expectedData = [
+            'sku--[sku]' => 'sku--[sku]',
+            'description--Description' => 'description--Description',
+            'name--Nom' => 'name--Nom',
+        ];
 
-        $this->present($data, ['with_label' => true, 'header_with_label' => false])->shouldReturn($data);
+        $this->present($data, ['with_label' => true, 'header_with_label' => false])->shouldReturn($expectedData);
     }
 
-    function it_format_duplicated_translations()
+    function it_formats_duplicated_translations()
     {
         $data = [
             'brand--Marque',
             'camera_brand--Marque',
             'size--Taille',
-            'objective_size--Taille'
+            'objective_size--Taille',
         ];
 
         $this->present($data, ['with_label' => true, 'header_with_label' => true])->shouldReturn([
-            'Marque - brand',
-            'Marque - camera_brand',
-            'Taille - size',
-            'Taille - objective_size',
+            'brand--Marque' => 'Marque - brand',
+            'camera_brand--Marque' => 'Marque - camera_brand',
+            'size--Taille' => 'Taille - size',
+            'objective_size--Taille' => 'Taille - objective_size',
         ]);
     }
 
-    function it_remove_code_when_translation_is_not_duplicated()
+    function it_removes_code_when_translation_is_not_duplicated()
     {
         $data = [
             'sku--[sku]',
@@ -45,11 +50,11 @@ class TranslatedColumnPresenterSpec extends ObjectBehavior
         ];
 
         $this->present($data, ['with_label' => true, 'header_with_label' => true])->shouldReturn([
-            '[sku]',
-            'Description',
-            'Nom',
-            'Marque - brand',
-            'Marque - camera_brand',
+            'sku--[sku]' => '[sku]',
+            'description--Description' => 'Description',
+            'name--Nom' => 'Nom',
+            'brand--Marque' => 'Marque - brand',
+            'camera_brand--Marque' => 'Marque - camera_brand',
         ]);
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

**Description (for Contributor and Core Developer)**

When exporting products or models with labels, the column presenter was used to generate column names for both the header row and "data" rows, which in some cases could lead to some inconsistencies, because "data" rows don't necessarily have values for each column. As a result, some values could be "out of bounds" (at the end of the row, in a column without header)
Now the column presenter returns a mapping `[original_column_name => translated_column_name]`, which is then used to prepare proper data rows

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
