### PR TITLE
PIM-11047: Be able to customize local storage root without breaking import/export

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11047: Be able to customize local storage root without breaking import/export
+
 # 7.0.17 (2023-05-24)
 
 # 7.0.16 (2023-05-24)

--- a/config/packages/behat/oneup_flysystem.yml
+++ b/config/packages/behat/oneup_flysystem.yml
@@ -18,7 +18,7 @@ oneup_flysystem:
                 bucket: 'category'
         local_storage_adapter:
             local:
-                location: '/'
+                location: '%local_storage_root%'
         catalogs_mapping_adapter:
             awss3v3:
                 client: 'Aws\S3\S3Client'

--- a/config/packages/dev/oneup_flysystem.yml
+++ b/config/packages/dev/oneup_flysystem.yml
@@ -14,7 +14,7 @@ oneup_flysystem:
                 location: '%kernel.project_dir%/var/file_storage/category'
         local_storage_adapter:
             local:
-                location: '/'
+                location: '%local_storage_root%'
         catalogs_mapping_adapter:
             local:
                 location: '%kernel.project_dir%/var/file_storage/catalogs_mapping'

--- a/config/packages/prod/oneup_flysystem.yml
+++ b/config/packages/prod/oneup_flysystem.yml
@@ -14,7 +14,7 @@ oneup_flysystem:
                 location: '%kernel.project_dir%/var/file_storage/category'
         local_storage_adapter:
             local:
-                location: '/'
+                location: '%local_storage_root%'
         catalogs_mapping_adapter:
             local:
                 location: '%kernel.project_dir%/var/file_storage/catalogs_mapping'

--- a/config/packages/test/oneup_flysystem.yml
+++ b/config/packages/test/oneup_flysystem.yml
@@ -18,7 +18,7 @@ oneup_flysystem:
                 bucket: 'category'
         local_storage_adapter:
             local:
-                location: '/'
+                location: '%local_storage_root%'
         catalogs_mapping_adapter:
             awss3v3:
                 client: 'Aws\S3\S3Client'

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -53,3 +53,5 @@ parameters:
     webhook_requests_limit: 4000
 
     openssl_config_path: '%pim_ce_dev_src_folder_location%/config/openssl.cnf'
+
+    local_storage_root: '/'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/DownloadStep.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/DownloadStep.php
@@ -30,6 +30,7 @@ final class DownloadStep extends AbstractStep
         EventDispatcherInterface $eventDispatcher,
         JobRepositoryInterface $jobRepository,
         private DownloadFileFromStorageHandler $downloadFileFromStorageHandler,
+        private readonly string $localStorageRoot,
     ) {
         parent::__construct($name, $eventDispatcher, $jobRepository);
     }
@@ -57,11 +58,12 @@ final class DownloadStep extends AbstractStep
             $jobExecution->getExecutionContext()->get(JobInterface::WORKING_DIRECTORY_PARAMETER),
         );
 
-        $outputFilePath = $this->downloadFileFromStorageHandler->handle($command);
+        $relativeOutputFilePath = $this->downloadFileFromStorageHandler->handle($command);
+        $absoluteOutputFilePath = str_replace('//', '/', $this->localStorageRoot . $relativeOutputFilePath);
 
         $storage = [
             'type' => LocalStorage::TYPE,
-            'file_path' => $outputFilePath,
+            'file_path' => $absoluteOutputFilePath,
         ];
         $jobExecution->getJobParameters()->set('storage', $storage);
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/DownloadStep.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/DownloadStep.php
@@ -59,7 +59,7 @@ final class DownloadStep extends AbstractStep
         );
 
         $relativeOutputFilePath = $this->downloadFileFromStorageHandler->handle($command);
-        $absoluteOutputFilePath = str_replace('//', '/', $this->localStorageRoot . $relativeOutputFilePath);
+        $absoluteOutputFilePath = str_replace('//', '/', $this->localStorageRoot.$relativeOutputFilePath);
 
         $storage = [
             'type' => LocalStorage::TYPE,

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/step.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/step.yml
@@ -6,6 +6,7 @@ services:
       - '@event_dispatcher'
       - '@akeneo_batch.job_repository'
       - '@Akeneo\Platform\Bundle\ImportExportBundle\Application\DownloadFileFromStorage\DownloadFileFromStorageHandler'
+      - '%local_storage_root%'
 
   akeneo.job_automation.connector.step.upload:
     class: Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Step\UploadStep


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I extracted the root location of local storage in a container param.
This param is now used to rebuild the absolute local file path in the download step.

Resolves #19688

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
