### PR TITLE
PIM-11057: Fix ScalarValue::__toString does not cast wrapped boolean value correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - PIM-10966: Fix error when toggling between tabs on an export profile editing page
 - PIM-10972: Fix shifting data during import
 - PIM-10950: Fix wrongly removed code filter on attribute page
+- PIM-11057: Fix ScalarValue::__toString does not cast wrapped boolean value correctly
 - PIM-10960: Fix no violation raised when importing variant with already existing siblings
 - PIM-10789: Fix password is displayed in SFTP and Amazon S3 form and encrypted password is displayed on history
 - PIM-10779: Fix lowercase on get attribute group code for dqi activation

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/ScalarValue.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/ScalarValue.php
@@ -45,7 +45,7 @@ class ScalarValue extends AbstractValue implements ValueInterface
         if (is_bool($this->data)) {
             return true === $this->data ? '1' : '0';
         }
-        return (string)$this->data;
+        return (string) $this->data;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/ScalarValue.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/ScalarValue.php
@@ -42,7 +42,10 @@ class ScalarValue extends AbstractValue implements ValueInterface
      */
     public function __toString(): string
     {
-        return (string) $this->data;
+        if (is_bool($this->data)) {
+            return true === $this->data ? '1' : '0';
+        }
+        return (string)$this->data;
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -844,7 +844,7 @@ JSON;
             "a_yes_no": [{
                 "locale": null,
                 "scope": null,
-                "data": false
+                "data": true
             }],
             "a_localizable_scopable_image": [{
                 "locale": "en_US",
@@ -922,7 +922,7 @@ JSON;
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
                 'a_yes_no'                           => [
-                    ['locale' => null, 'scope' => null, 'data' => false],
+                    ['locale' => null, 'scope' => null, 'data' => true],
                 ],
                 'a_text_area'                           => [
                     ['locale' => null, 'scope' => null, 'data' => 'this is a very very very very very long  text'],
@@ -1052,7 +1052,7 @@ JSON;
         $this->createVariantProduct('apollon_option_b_true', [
             new SetCategories(['master']),
             new ChangeParent('amor'),
-            new SetBooleanValue('a_yes_no', null, null, false)
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -1068,7 +1068,7 @@ JSON;
               {
                 "locale": null,
                 "scope": null,
-                "data": false
+                "data": null
               }
             ]
         }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -1068,7 +1068,7 @@ JSON;
               {
                 "locale": null,
                 "scope": null,
-                "data": null
+                "data": true
               }
             ]
         }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
@@ -870,7 +870,7 @@ JSON;
             "a_yes_no": [{
                 "locale": null,
                 "scope": null,
-                "data": false
+                "data": true
             }],
             "a_localizable_scopable_image": [{
                 "locale": "en_US",
@@ -948,7 +948,7 @@ JSON;
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
                 'a_yes_no'                           => [
-                    ["locale" => null, "scope" => null, "data" => false],
+                    ["locale" => null, "scope" => null, "data" => true],
                 ],
                 'a_text_area'                           => [
                     ["locale" => null, "scope" => null, "data" => 'this is a very very very very very long  text'],
@@ -1080,7 +1080,7 @@ JSON;
         $this->createVariantProduct('apollon_option_b_true', [
             new SetCategories(['master']),
             new ChangeParent('amor'),
-            new SetBooleanValue('a_yes_no', null, null, false)
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -1098,7 +1098,7 @@ JSON;
               {
                 "locale": null,
                 "scope": null,
-                "data": false
+                "data": true
               }
             ]
         }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -95,7 +95,7 @@ class PartialUpdateVariantProductEndToEnd extends AbstractProductTestCase
             {
               "locale": null,
               "scope": null,
-              "data": false
+              "data": true
             }
           ]
         }
@@ -145,7 +145,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => false,
+                        "data"   => true,
                     ],
                 ],
             ],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductWithUuidEndToEnd.php
@@ -104,7 +104,7 @@ class PartialUpdateVariantProductWithUuidEndToEnd extends AbstractProductTestCas
             {
               "locale": null,
               "scope": null,
-              "data": false
+              "data": true
             }
           ],
           "sku": [{"locale": null, "scope": null, "data": "product_variant_create_with_identifier" }]
@@ -155,7 +155,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => false,
+                        "data"   => true,
                     ],
                 ],
             ],
@@ -195,7 +195,7 @@ JSON;
             {
               "locale": null,
               "scope": null,
-              "data": false
+              "data": true
             }
           ],
           "sku": [{"locale": null, "scope": null, "data": "product_variant_create_with_identifier" }]
@@ -246,7 +246,7 @@ JSON;
                     [
                         "locale" => null,
                         "scope"  => null,
-                        "data"   => false,
+                        "data"   => true,
                     ],
                 ],
             ],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlGetValuesOfSiblingsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlGetValuesOfSiblingsIntegration.php
@@ -54,15 +54,18 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
 
     public function test_that_it_gets_the_siblings_values_of_a_new_variant_product()
     {
-        $variantProduct = $this->createProduct('new_identifier', [
-            new ChangeParent('sub_sweat_option_a'),
-            new SetBooleanValue('a_yes_no', null, null, false)
-        ]);
+        $variantProduct = $this->createProduct(
+            'apollon_optionb_false',
+            [
+                new SetCategories(['master']),
+                new ChangeParent('sub_sweat_option_b'),
+                new SetBooleanValue('a_yes_no', null, null, false)
+            ]
+        );
 
         $valuesOfSiblings = $this->getValuesOfSiblings($variantProduct);
-        Assert::assertCount(2, $valuesOfSiblings);
-        Assert::assertArrayHasKey('apollon_optiona_true', $valuesOfSiblings);
-        Assert::assertArrayHasKey('apollon_optiona_false', $valuesOfSiblings);
+        Assert::assertCount(1, $valuesOfSiblings);
+        Assert::assertArrayHasKey('apollon_optionb_true', $valuesOfSiblings);
     }
 
     public function test_that_it_gets_the_siblings_values_of_an_existing_variant_product()
@@ -182,6 +185,14 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
                 new SetCategories(['master']),
                 new ChangeParent('sub_sweat_option_a'),
                 new SetBooleanValue('a_yes_no', null, null, false)
+            ]
+        );
+        $this->createProduct(
+            'apollon_optionb_true',
+            [
+                new SetCategories(['master']),
+                new ChangeParent('sub_sweat_option_b'),
+                new SetBooleanValue('a_yes_no', null, null, true)
             ]
         );
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The UniqueVariantAxisValidator does not invalidate a duplicated variant on a boolean axis because the ScalarValue does not cast wrapped boolean value to string correctly.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
