### PR TITLE
PIM-11063: Fix generated identifier validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PIM-11050 : On "locale" DIV, missing the indication of the country
 - PIM-11039: Fix export with duplicated labels
 - PIM-10869: Image upload fields now only accept images
+- PIM-11063: Fix validation of generated identifiers
 
 ## Improvements
 

--- a/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
@@ -86,8 +86,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ProductInterface $product,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
-        ClassMetadataInterface $productMetadata,
-        PropertyMetadataInterface $productPropertyMetadata,
     ): void {
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = IdentifierValue::value('sku', true, 'AKN');
@@ -98,11 +96,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
         $product->getValues()->shouldBeCalled()->willReturn(new WriteValueCollection([]));
 
-        $unique = new UniqueProductEntity();
-        $metadataFactory->getMetadataFor($product)->shouldBeCalled()->willReturn($productMetadata);
-        $productMetadata->getPropertyMetadata('identifier')->shouldBeCalled()->willReturn([$productPropertyMetadata]);
-        $productPropertyMetadata->getConstraints()->shouldBeCalled()->willReturn([]);
-        $validator->validate($product, [$unique])
+        $validator->validate($product, null, ['identifiers'])
             ->shouldBeCalled()
             ->willReturn(new ConstraintViolationList([]));
 
@@ -128,8 +122,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         LoggerInterface $logger,
         ProductInterface $product,
         MetadataFactoryInterface $metadataFactory,
-        ClassMetadataInterface $productMetadata,
-        PropertyMetadataInterface $productPropertyMetadata,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
     ): void {
@@ -142,11 +134,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
         $product->getValues()->shouldBeCalled()->willReturn(new WriteValueCollection([]));
 
-        $unique = new UniqueProductEntity();
-        $metadataFactory->getMetadataFor($product)->shouldBeCalled()->willReturn($productMetadata);
-        $productMetadata->getPropertyMetadata('identifier')->shouldBeCalled()->willReturn([$productPropertyMetadata]);
-        $productPropertyMetadata->getConstraints()->shouldBeCalled()->willReturn([]);
-        $validator->validate($product, [$unique])
+        $validator->validate($product, null, ['identifiers'])
             ->shouldBeCalled()
             ->willReturn(new ConstraintViolationList([
                 new ConstraintViolation('', '', [], '', '', ''),
@@ -175,8 +163,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         MetadataFactoryInterface $metadataFactory,
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
-        ClassMetadataInterface $productMetadata,
-        PropertyMetadataInterface $productPropertyMetadata,
     ): void {
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = IdentifierValue::value('sku', true, 'AKN');
@@ -187,11 +173,7 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         $product->getCategoryCodes()->shouldBeCalled()->willReturn([]);
         $product->getValues()->shouldBeCalled()->willReturn(new WriteValueCollection([]));
 
-        $unique = new UniqueProductEntity();
-        $metadataFactory->getMetadataFor($product)->shouldBeCalled()->willReturn($productMetadata);
-        $productMetadata->getPropertyMetadata('identifier')->shouldBeCalled()->willReturn([$productPropertyMetadata]);
-        $productPropertyMetadata->getConstraints()->shouldBeCalled()->willReturn([]);
-        $validator->validate($product, [$unique])
+        $validator->validate($product, null, ['identifiers'])
             ->shouldBeCalled()
             ->willReturn(new ConstraintViolationList([]));
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -1,11 +1,13 @@
 Akeneo\Pim\Enrichment\Component\Product\Model\Product:
     group_sequence:
         - Product
+        - identifiers
         - VariantProduct
         - UniqueAxis
         - api
     constraints:
-        - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductEntity: ~
+        - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductEntity:
+              groups: ['identifiers']
         - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotEmptyFamily:
             groups:
               - api
@@ -23,13 +25,16 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
             - Regex:
                 pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'
+                groups: ['identifiers']
             - Regex:
                 pattern: '/[\r\n]/'
                 message: 'regex.line_break.message'
                 match: false
+                groups: ['identifiers']
             - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Length:
                 max: 255
                 attributeCode: 'identifier'
+                groups: ['identifiers']
         associations:
             - Symfony\Component\Validator\Constraints\All:
                 - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\AssociationTypeIsNotQuantified: ~


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes the validation of a generated identifier:
In some cases, some constraints returned by the MetadataFactory would apply to the product itself, instead of its properties (here, the `identifier` property). It's the case of the Regex validator, which would validate the `$product->__toSttring()` (i.e the value of the attribute as label) instead of the product identifier.
Here, we simply add a validation group and validate the product only on this validation group, letting the validator decide which constraints to apply on which properties of the product

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
