### PR TITLE
RAB-1445: Add ZDDmigration in order to remove the old instant cols on mysql server in order to avoid having index corruption

### DIFF
--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/doctrine.yml
@@ -28,3 +28,10 @@ services:
             - '%akeneo_storage_utils.mapping_overrides%'
         tags:
             - { name: doctrine.event_subscriber, priority: 100 }
+
+    Akeneo\Tool\Component\StorageUtils\Migration\V20230622175500OptimizeTableWithInstantColsMigration:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'akeneo.pim.zdd_migration' }
+        public: true

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest.php
@@ -18,14 +18,14 @@ use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;
 
 /**
- * This test exist in order to enforce the fact that we cannot create new columns on some table until we didn't do an OPTIMIZE TABLE on those table.
+ * This test exists in order to prevent new columns creation on large tables until we perform an `OPTIMIZE TABLE` on those tables.
  *
  * Link to the incident related:
  *     - https://www.notion.so/akeneo/2023-06-01-MySQL-crash-loop-6796c8a1656c49daaa986aa53274bc71
  *     - https://akeneo.slack.com/archives/C05A8TT1UCW/p1686739172807109
  *
- * Actually making an OPTIMIZE table on those table create a MySQL error on some large instances due to the fact that it require a lot of space to do it.
- * When UCS migration will be finished we didn't need to do it anymore as it made a MySQL dump and restore because the table will be rebuilt
+ * Currently, performing an `OPTIMIZE TABLE` on those tables create a MySQL error on instances with a lot of data due to the fact that it requires a lot of available space.
+ * When UCS migration will be over, we won't need to do it anymore because the UCS migration actually rebuilds the table and dump previous data into it.
  */
 class TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest extends TestCase
 {

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/tests/integration/TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2023 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\StorageUtilsBundle\tests\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * This test exist in order to enforce the fact that we cannot create new columns on some table until we didn't do an OPTIMIZE TABLE on those table.
+ *
+ * Link to the incident related:
+ *     - https://www.notion.so/akeneo/2023-06-01-MySQL-crash-loop-6796c8a1656c49daaa986aa53274bc71
+ *     - https://akeneo.slack.com/archives/C05A8TT1UCW/p1686739172807109
+ *
+ * Actually making an OPTIMIZE table on those table create a MySQL error on some large instances due to the fact that it require a lot of space to do it.
+ * When UCS migration will be finished we didn't need to do it anymore as it made a MySQL dump and restore because the table will be rebuilt
+ */
+class TableWithOldInstantColsCannotHaveNewColumnUntilUcsMigrationTest extends TestCase
+{
+    public function test_large_table_cannot_add_new_column()
+    {
+        $this->assertEquals(['identifier', 'code', 'asset_family_identifier', 'value_collection', 'created_at', 'updated_at'], $this->getColumns('akeneo_asset_manager_asset'));
+        $this->assertEquals(['id', 'parent_id', 'family_variant_id', 'code', 'raw_values', 'created', 'updated', 'quantified_associations'], $this->getColumns('pim_catalog_product_model'));
+        $this->assertEquals(['product_model_id','evaluated_at','scores', 'scores_partial_criteria'], $this->getColumns('pim_data_quality_insights_product_model_score'));
+    }
+
+    private function getColumns(string $tableName): array
+    {
+        $sql = <<<SQL
+            SELECT COLUMN_NAME
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_SCHEMA = DATABASE() 
+            AND TABLE_NAME = :tableName
+            ORDER BY ORDINAL_POSITION;
+        SQL;
+
+        return $this->getConnection()->executeQuery($sql, [
+            'tableName' => $tableName,
+        ])->fetchFirstColumn();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -66,6 +66,6 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
             OPTIMIZE TABLE $tableName;
         SQL;
 
-        $this->connection->executeStatement($sql);
+        $this->connection->executeQuery($sql);
     }
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\StorageUtils\Migration;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Command\ZddMigration;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigration
+{
+    private const TABLES_THAT_CAN_HAVE_INSTANT_COLS = [
+        'akeneo_asset_manager_asset',
+        'akeneo_asset_manager_asset_family',
+        'akeneo_asset_manager_attribute',
+        'akeneo_batch_job_execution',
+        'akeneo_batch_step_execution',
+        'akeneo_connectivity_connection',
+        'akeneo_reference_entity_record',
+        'akeneo_rule_engine_rule_definition',
+        'oro_access_group',
+        'oro_user',
+        'pim_api_client',
+        'pim_catalog_association_type',
+        'pim_catalog_category',
+        'pim_catalog_category_template',
+        'pim_catalog_product_model',
+        'pim_data_quality_insights_product_model_score',
+        'pimee_data_quality_insights_text_checker_dictionary',
+        'pimee_workflow_product_model_draft',
+    ];
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function migrate(): void
+    {
+        foreach (self::TABLES_THAT_CAN_HAVE_INSTANT_COLS as $tableName) {
+            if (!$this->tableHaveInstantCol($tableName)) {
+                continue;
+            }
+
+            $this->optimizeTable($tableName);
+        }
+    }
+
+    public function migrateNotZdd(): void
+    {
+        $this->migrate();
+    }
+
+    public function getName(): string
+    {
+        return 'OptimizeTableWithInstantCols';
+    }
+
+    private function tableHaveInstantCol(string $tableName): bool
+    {
+        $schema = $this->connection->getDatabase();
+        $sql = <<<SQL
+            SELECT EXISTS(
+                SELECT * 
+                FROM information_schema.innodb_tables 
+                WHERE INSTANT_COLS > 0
+                AND NAME = :innodb_table_name
+            );
+        SQL;
+
+        $result = $this->connection->fetchOne($sql, [
+            'innodb_table_name' => sprintf('%s/%s', $schema, $tableName)
+        ]);
+
+        return $result === 'YES';
+    }
+
+    private function optimizeTable(string $tableName)
+    {
+        $sql = <<<SQL
+            OPTIMIZE TABLE :table_name;
+        SQL;
+
+        $this->connection->executeStatement($sql, [
+            'table_name' => $tableName
+        ]);
+    }
+}

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -54,11 +54,9 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
     private function optimizeTable(string $tableName)
     {
         $sql = <<<SQL
-            OPTIMIZE TABLE :table_name;
+            OPTIMIZE TABLE $tableName;
         SQL;
 
-        $this->connection->executeStatement($sql, [
-            'table_name' => $tableName
-        ]);
+        $this->connection->executeStatement($sql);
     }
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -13,12 +13,10 @@ use Doctrine\DBAL\Connection;
  */
 class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigration
 {
-    private const TABLES_THAT_CAN_HAVE_INSTANT_COLS = [
-        'akeneo_asset_manager_asset',
+    private const TABLES_THAT_HAVE_INSTANT_COLS = [
         'akeneo_asset_manager_asset_family',
         'akeneo_asset_manager_attribute',
         'akeneo_batch_job_execution',
-        'akeneo_batch_step_execution',
         'akeneo_connectivity_connection',
         'akeneo_reference_entity_record',
         'akeneo_rule_engine_rule_definition',
@@ -28,8 +26,6 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
         'pim_catalog_association_type',
         'pim_catalog_category',
         'pim_catalog_category_template',
-        'pim_catalog_product_model',
-        'pim_data_quality_insights_product_model_score',
         'pimee_data_quality_insights_text_checker_dictionary',
         'pimee_workflow_product_model_draft',
     ];
@@ -40,7 +36,7 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
 
     public function migrate(): void
     {
-        foreach (self::TABLES_THAT_CAN_HAVE_INSTANT_COLS as $tableName) {
+        foreach (self::TABLES_THAT_HAVE_INSTANT_COLS as $tableName) {
             $this->optimizeTable($tableName);
         }
     }

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -36,19 +36,28 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
 
     public function migrate(): void
     {
-        foreach (self::TABLES_THAT_HAVE_INSTANT_COLS as $tableName) {
-            $this->optimizeTable($tableName);
-        }
+        $this->optimizeTables(self::TABLES_THAT_HAVE_INSTANT_COLS);
     }
 
     public function migrateNotZdd(): void
     {
-        $this->migrate();
+        $this->optimizeTables(array_merge(self::TABLES_THAT_HAVE_INSTANT_COLS, [
+            'akeneo_asset_manager_asset',
+            'pim_catalog_product_model',
+            'pim_data_quality_insights_product_model_score',
+        ]));
     }
 
     public function getName(): string
     {
         return 'OptimizeTableWithInstantCols';
+    }
+
+    private function optimizeTables(array $tableNames)
+    {
+        foreach ($tableNames as $tableName) {
+            $this->optimizeTable($tableName);
+        }
     }
 
     private function optimizeTable(string $tableName)

--- a/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Migration/V20230622175500OptimizeTableWithInstantColsMigration.php
@@ -41,10 +41,6 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
     public function migrate(): void
     {
         foreach (self::TABLES_THAT_CAN_HAVE_INSTANT_COLS as $tableName) {
-            if (!$this->tableHaveInstantCol($tableName)) {
-                continue;
-            }
-
             $this->optimizeTable($tableName);
         }
     }
@@ -57,25 +53,6 @@ class V20230622175500OptimizeTableWithInstantColsMigration implements ZddMigrati
     public function getName(): string
     {
         return 'OptimizeTableWithInstantCols';
-    }
-
-    private function tableHaveInstantCol(string $tableName): bool
-    {
-        $schema = $this->connection->getDatabase();
-        $sql = <<<SQL
-            SELECT EXISTS(
-                SELECT * 
-                FROM information_schema.innodb_tables 
-                WHERE INSTANT_COLS > 0
-                AND NAME = :innodb_table_name
-            );
-        SQL;
-
-        $result = $this->connection->fetchOne($sql, [
-            'innodb_table_name' => sprintf('%s/%s', $schema, $tableName)
-        ]);
-
-        return $result === 'YES';
     }
 
     private function optimizeTable(string $tableName)

--- a/upgrades/.php_cd.php
+++ b/upgrades/.php_cd.php
@@ -25,6 +25,7 @@ $rules = [
             'Symfony\Component\DependencyInjection\ContainerAwareTrait',
             // ZDD migrations
             'Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations',
+            'Akeneo\Tool\Component\StorageUtils\Migration\V20230622175500OptimizeTableWithInstantColsMigration',
 
             // Dangerous dependencies, migrations shouldn't rely on services
             'Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys',

--- a/upgrades/schema/Version_8_0_20230627173000_remove_instant_cols.php
+++ b/upgrades/schema/Version_8_0_20230627173000_remove_instant_cols.php
@@ -19,7 +19,7 @@ final class Version_8_0_20230627173000_remove_instant_cols extends AbstractMigra
     public function up(Schema $schema): void
     {
         $this->disableMigrationWarning();
-        if ($this->isSassVersion()){
+        if ($this->isSaaSVersion()){
             return;
         }
 
@@ -41,7 +41,7 @@ final class Version_8_0_20230627173000_remove_instant_cols extends AbstractMigra
         return $this->container->get('Akeneo\Tool\Component\StorageUtils\Migration\V20230622175500OptimizeTableWithInstantColsMigration');
     }
 
-    private function isSassVersion(): bool
+    private function isSaaSVersion(): bool
     {
         /** @var VersionProviderInterface $versionProvider */
         $versionProvider = $this->container->get('pim_catalog.version_provider');

--- a/upgrades/schema/Version_8_0_20230627173000_remove_instant_cols.php
+++ b/upgrades/schema/Version_8_0_20230627173000_remove_instant_cols.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations\V20220729171405DropProductIdColumnsAndCleanVersioningResourceUuidColumns;
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Akeneo\Tool\Component\StorageUtils\Migration\V20230622175500OptimizeTableWithInstantColsMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_8_0_20230627173000_remove_instant_cols extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container = null;
+
+    public function up(Schema $schema): void
+    {
+        $this->disableMigrationWarning();
+        if ($this->isSassVersion()){
+            return;
+        }
+
+        $this->getMigration()->migrateNotZdd();
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    private function getMigration(): V20230622175500OptimizeTableWithInstantColsMigration
+    {
+        return $this->container->get('Akeneo\Tool\Component\StorageUtils\Migration\V20230622175500OptimizeTableWithInstantColsMigration');
+    }
+
+    private function isSassVersion(): bool
+    {
+        /** @var VersionProviderInterface $versionProvider */
+        $versionProvider = $this->container->get('pim_catalog.version_provider');
+
+        return $versionProvider->isSaaSVersion();
+    }
+
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+}

--- a/upgrades/test_schema/Version_8_0_20230627173000_remove_instant_cols_Integration.php
+++ b/upgrades/test_schema/Version_8_0_20230627173000_remove_instant_cols_Integration.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+final class Version_8_0_20230627173000_remove_instant_cols_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_8_0_20230627173000_remove_instant_cols';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    /**
+     * To reproduce the scenario we should be in MySQL < 8.0.29 and then upgrade to 8.0.30,
+     * as it's impossible we just test that the migration can be launched
+     */
+    public function testItLaunchOptimizeOnSeveralTable()
+    {
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I added a new migration in order to launch OPTIMIZE operation on table that have instant_col > 0 in order to rebuilt those table in order to avoid having table corruption like we had in production (cf  https://www.notion.so/akeneo/2023-06-01-MySQL-crash-loop-6796c8a1656c49daaa986aa53274bc71, https://akeneo.slack.com/archives/C05A8TT1UCW/p1686739172807109)

As some table have more than 1 million lines we decided to do not launch OPTIMIZE TABLE because it throw an error due to the fact that it required too much memory. As UCS coming, I added a test in order to validate that there is no new column on those table until UCS migration is finished.


Tested on multiple clone: 
- srnt-cto-pim: 127s
- srnt-madeira-production: 116s
- srnt-iteshop: 12s
- srnt-kering: 9s
- srnt-pim-pce: 135s

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
