### PR TITLE
Mute warning about missing tenant id when not in prod

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -21,6 +21,7 @@ class UcsMiddleware implements MiddlewareInterface
     public function __construct(
         private readonly ?string $pimTenantId,
         private readonly LoggerInterface $logger,
+        private readonly ?string $environment = 'prod',
     ) {
     }
 
@@ -30,7 +31,7 @@ class UcsMiddleware implements MiddlewareInterface
         // If there is none, we fallback on the tenantid coming from the env variables.
         $tenantId = $envelope->last(TenantIdStamp::class)?->pimTenantId() ?: $this->pimTenantId;
 
-        if (empty($tenantId)) {
+        if ($this->environment === 'prod' && empty($tenantId)) {
             $this->logger->warning(sprintf(
                 'A message of type "%s" is consumed without a tenant id available',
                 get_class($envelope->getMessage()),

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
@@ -17,6 +17,7 @@ services:
         arguments:
             - '%env(default::string:APP_TENANT_ID)%'
             - '@logger'
+            - '%kernel.environment%'
 
     Akeneo\Tool\Bundle\MessengerBundle\Process\RunMessageProcess:
         arguments:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In UcsMiddleware, a warning is raised if there is no tenant id available.
This is a good thing to have in UCS production.
But it's annoying to have the logs polluted by this when developing locally.

With the proposed change, the warning will only be raised in production, not in dev.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
