### PR TITLE
PIM-11066: Fix Missing Values Adder for scopable + localizable + locale specific attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - PIM-11039: Fix export with duplicated labels
 - PIM-10869: Image upload fields now only accept images
 - PIM-11063: Fix validation of generated identifiers
+- PIM-11066: PIM-11066: Fix Missing Values Adder for scopable + localizable + locale specific attributes
 
 ## Improvements
 

--- a/tests/back/Common/Structure/Attribute/Builder.php
+++ b/tests/back/Common/Structure/Attribute/Builder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Test\Common\Structure\Attribute;
 
 use Akeneo\Channel\Infrastructure\Component\Model\Locale;
+use Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface;
 use Akeneo\Test\Common\EntityWithValue\Code;
 use Akeneo\Pim\Structure\Component\Model;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
@@ -33,8 +34,8 @@ class Builder
     /** @var bool */
     private $localizable;
 
-    /** @var bool */
-    private $specificlocalizable;
+    /** @var LocaleInterface[]  */
+    private $availableLocales = [];
 
     /** @var bool */
     private $scopable;
@@ -67,10 +68,8 @@ class Builder
         $attribute->setUnique($this->isUnique);
         $attribute->setScopable($this->scopable);
         $attribute->setLocalizable($this->localizable);
-        if ($this->specificlocalizable) {
-            $locale = new Locale();
-            $locale->setCode("locale_code");
-            $attribute->addAvailableLocale(new Locale());
+        foreach ($this->availableLocales as $availableLocale) {
+            $attribute->addAvailableLocale($availableLocale);
         }
         $attribute->setDecimalsAllowed(false);
         $attribute->setBackendType($this->backendType);
@@ -162,8 +161,10 @@ class Builder
         return $this;
     }
 
-    public function  specificlocalizable(): Builder {
-        $this->specificlocalizable =true;
+    public function localeSpecific(array $locales): Builder
+    {
+        $this->availableLocales = $locales;
+
         return $this;
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductModelValuesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductModelValuesSpec.php
@@ -21,8 +21,11 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $familyVariantRepository,
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository
-    )
-    {
+    ) {
+        $deDe = (new Locale())->setCode('de_DE');
+        $enUs = (new Locale())->setCode('en_US');
+        $frFR = (new Locale())->setCode('fr_FR');
+
         $sku = (new Builder())->aIdentifier()->withCode('sku')->build();
         $name = (new Builder())->aTextAttribute()->withCode('name')->build();
         $localizableName = (new Builder())->aTextAttribute()->withCode('localizable_name')->localizable()->build();
@@ -38,7 +41,7 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
             ->scopable()->localizable()->build();
 
         $family = new Family();
-        $specificLocalizableName = (new Builder())->aTextAttribute()->withCode('specific_localizable_name')->specificlocalizable()->build();
+        $specificLocalizableName = (new Builder())->aTextAttribute()->withCode('specific_localizable_name')->localeSpecific([$frFR])->build();
         $family
             ->addAttribute($sku)
             ->addAttribute($name)
@@ -54,7 +57,7 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
             ->addAttribute(
                 (new Builder())
                     ->aTextAttribute()
-                    ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->specificlocalizable()
+                    ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->localeSpecific([$frFR, $enUs])
                     ->build()
             );
 
@@ -85,10 +88,6 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
         $attributeSet->setAttributes([$sku, $name, $localizableName, $scopableName, $scopableLocalizableName, $attributeWithNumericCode]);
         $familyVariantWithPrices->addVariantAttributeSet($attributeSet);
         $familyVariantRepository->findOneByIdentifier('with_prices')->willReturn($familyVariantWithPrices);
-
-        $deDe = (new Locale())->setCode('de_DE');
-        $enUs = (new Locale())->setCode('en_US');
-        $frFR = (new Locale())->setCode('fr_FR');
 
         $USD = (new Currency())->setCode('USD');
         $EUR = (new Currency())->setCode('EUR');
@@ -146,12 +145,17 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'en_US',
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'tablet',
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],
@@ -186,14 +190,14 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     '123' => [
                         ['scope' => null, 'locale' => null, 'data' => null],
                     ],
+                    'scopable_name' => [
+                        ['scope' => 'tablet', 'locale' => null, 'data' => null],
+                        ['scope' => 'ecommerce', 'locale' => null, 'data' => null],
+                    ],
                     'localizable_name' => [
                         ['scope' => null, 'locale' => 'en_US', 'data' => null],
                         ['scope' => null, 'locale' => 'fr_FR', 'data' => null],
                         ['scope' => null, 'locale' => 'de_DE', 'data' => null],
-                    ],
-                    'scopable_name' => [
-                        ['scope' => 'tablet', 'locale' => null, 'data' => null],
-                        ['scope' => 'ecommerce', 'locale' => null, 'data' => null],
                     ],
                     'specific_localizable_name' => [[
                         'scope' => null,
@@ -203,12 +207,17 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'en_US',
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'tablet',
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],
@@ -275,12 +284,17 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'en_US',
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'tablet',
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],
@@ -402,12 +416,17 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'en_US',
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'tablet',
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],
@@ -591,12 +610,17 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'en_US',
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'tablet',
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
@@ -23,8 +23,31 @@ class FillMissingProductValuesSpec extends ObjectBehavior
         ChannelRepositoryInterface $channelRepository,
         LocaleRepositoryInterface $localeRepository,
         GetAttributes $getAttributes
-    )
-    {
+    ) {
+        $deDe = new Locale();
+        $enUs = new Locale();
+        $frFR = new Locale();
+        $deDe->setCode('de_DE');
+        $enUs->setCode('en_US');
+        $frFR->setCode('fr_FR');
+
+        $USD = new Currency();
+        $EUR = new Currency();
+        $AED = new Currency();
+        $USD->setCode('USD');
+        $EUR->setCode('EUR');
+        $AED->setCode('AED');
+
+        $tablet = new Channel();
+        $tablet->setCode('tablet');
+        $tablet->setLocales([$enUs, $frFR]);
+        $tablet->setCurrencies([$AED, $EUR]);
+
+        $ecommerce = new Channel();
+        $ecommerce->setCode('ecommerce');
+        $ecommerce->setLocales([$frFR, $deDe]);
+        $ecommerce->setCurrencies([$USD, $EUR]);
+
         $family = new Family();
 
         $family->addAttribute(
@@ -34,12 +57,12 @@ class FillMissingProductValuesSpec extends ObjectBehavior
             (new Builder())->aTextAttribute()->withCode('localizable_name')->localizable()->build()
         );
         $family->addAttribute(
-            (new Builder())->aTextAttribute()->withCode('specific_localizable_name')->specificlocalizable()->build()
+            (new Builder())->aTextAttribute()->withCode('specific_localizable_name')->localeSpecific([$frFR])->build()
         );
         $family->addAttribute(
             (new Builder())
                 ->aTextAttribute()
-                ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->specificlocalizable()
+                ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->localeSpecific([$frFR])
                 ->build()
         );
 
@@ -70,30 +93,6 @@ class FillMissingProductValuesSpec extends ObjectBehavior
 
         $familyRepository->findOneByIdentifier('shoes')->willReturn($family);
         $familyRepository->findOneByIdentifier('family_with_price')->willReturn($familyWithPrice);
-
-        $deDe = new Locale();
-        $enUs = new Locale();
-        $frFR = new Locale();
-        $deDe->setCode('de_DE');
-        $enUs->setCode('en_US');
-        $frFR->setCode('fr_FR');
-
-        $USD = new Currency();
-        $EUR = new Currency();
-        $AED = new Currency();
-        $USD->setCode('USD');
-        $EUR->setCode('EUR');
-        $AED->setCode('AED');
-
-        $tablet = new Channel();
-        $tablet->setCode('tablet');
-        $tablet->setLocales([$enUs, $frFR]);
-        $tablet->setCurrencies([$AED, $EUR]);
-
-        $ecommerce = new Channel();
-        $ecommerce->setCode('ecommerce');
-        $ecommerce->setLocales([$frFR, $deDe]);
-        $ecommerce->setCurrencies([$USD, $EUR]);
 
         $channelRepository->findAll()->willReturn([$tablet, $ecommerce]);
         $localeRepository->getActivatedLocales()->willReturn([$enUs, $frFR, $deDe]);
@@ -150,12 +149,12 @@ class FillMissingProductValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],
@@ -295,12 +294,12 @@ class FillMissingProductValuesSpec extends ObjectBehavior
                     'scopable_localizable_locale_specific_name' => [
                         [
                             'scope' => 'tablet',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                         [
                             'scope' => 'ecommerce',
-                            'locale' => null,
+                            'locale' => 'fr_FR',
                             'data' => null
                         ],
                     ],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

In the MissingValuesAdder, when an attribute was locale-specific but the locale did not belong to the channel, the empty value was still generated, causing issues when trying to save the product from the PEF.

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
