### PR TITLE
PIM-11070: [SLA] [Backport] PIM-10983 - Error HTTP 500 when adding a custom app

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,6 +1,6 @@
 # 6.0.x
 
-- PIM-11070: increase the oro_access_role label column to VARCHAR(255)
+- PIM-11070: Increase the oro_access_role label column to VARCHAR(255)
 
 # 6.0.89 (2023-06-29)
 

--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+- PIM-11070: increase the oro_access_role label column to VARCHAR(255)
+
 # 6.0.89 (2023-06-29)
 
 ## Improvements

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AppRoleWithScopesFactory.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AppRoleWithScopesFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Infrastructure\Apps;
 
 use Akeneo\Connectivity\Connection\Application\Apps\AppRoleWithScopesFactoryInterface;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseLabelLengthQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\UserManagement\Component\Connector\RoleWithPermissions;
@@ -22,19 +23,33 @@ final class AppRoleWithScopesFactory implements AppRoleWithScopesFactoryInterfac
     private ScopeMapperRegistry $scopeMapperRegistry;
     private SimpleFactoryInterface $roleFactory;
     private RoleWithPermissionsSaver $roleWithPermissionsSaver;
+    // Pull-up master: do not keep this property
+    private IncreaseLabelLengthQuery $increaseLabelLengthQuery;
 
     public function __construct(
         ScopeMapperRegistry $scopeMapperRegistry,
         SimpleFactoryInterface $roleFactory,
-        RoleWithPermissionsSaver $roleWithPermissionsSaver
+        RoleWithPermissionsSaver $roleWithPermissionsSaver,
+        // Pull-up master: do not keep this property
+        ?IncreaseLabelLengthQuery $increaseLabelLengthQuery = null
     ) {
         $this->scopeMapperRegistry = $scopeMapperRegistry;
         $this->roleFactory = $roleFactory;
         $this->roleWithPermissionsSaver = $roleWithPermissionsSaver;
+        // Pull-up master: do not keep this property
+        $this->increaseLabelLengthQuery = $increaseLabelLengthQuery;
     }
 
     public function createRole(string $label, array $scopes): RoleInterface
     {
+        /**
+         * Pull-up master: remove the call to `increaseScopeLength()`. It's a workaround to not
+         * create a migration on a released version.
+         */
+        if (null !== $this->increaseLabelLengthQuery) {
+            $this->increaseLabelLengthQuery->execute();
+        }
+
         /** @var RoleInterface $role */
         $role = $this->roleFactory->create();
         $role->setRole($this->createRandomRoleCode());

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/IncreaseLabelLengthQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/IncreaseLabelLengthQuery.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Pull-up master: do not pull this class: a migration handles the length's increase.
+ */
+final class IncreaseLabelLengthQuery
+{
+    public function __construct(
+        private Connection $connection
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+        if (!is_string($databaseName)) {
+            return;
+        }
+
+        $this->increaseLabelLength($databaseName);
+    }
+
+    private function increaseLabelLength(string $databaseName): void
+    {
+        $sql = <<< SQL
+            SELECT CHARACTER_MAXIMUM_LENGTH 
+            FROM information_schema.COLUMNS 
+            WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'oro_access_role' AND COLUMN_NAME = 'label';
+        SQL;
+
+        $scopeLength = $this->connection->executeQuery($sql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        if ('255' === $scopeLength) {
+            return;
+        }
+
+        $this->connection->executeQuery('ALTER TABLE oro_access_role MODIFY label VARCHAR(255) DEFAULT NULL');
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
@@ -61,6 +61,8 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry'
             - '@pim_user.factory.role'
             - '@pim_user.saver.role_with_permissions'
+            # Pull-up master: do not inject
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseLabelLengthQuery'
         public: true
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\AsymmetricKeysGenerator:
@@ -180,5 +182,10 @@ services:
 
     # Pull-up master: do not declare this service
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseScopeLengthQuery:
+        arguments:
+            - '@database_connection'
+
+    # Pull-up master: do not declare this service
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseLabelLengthQuery:
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/IncreaseLabelLengthQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/IncreaseLabelLengthQueryIntegration.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence\Query;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseLabelLengthQuery;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Pull-up master: do not pull this class: a migration handles the length's increase.
+ */
+class IncreaseLabelLengthQueryIntegration extends TestCase
+{
+    private IncreaseLabelLengthQuery $query;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->query = $this->get(IncreaseLabelLengthQuery::class);
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_updates_label_column_length(): void
+    {
+        if ('30' !== $this->getAccessRoleLabelLength()) {
+            $this->resetDefaultScopeColumnsLength();
+        }
+
+        $this->assertEquals('30', $this->getAccessRoleLabelLength());
+
+        $this->query->execute();
+
+        $this->assertEquals('255', $this->getAccessRoleLabelLength());
+    }
+
+    private function getAccessRoleLabelLength(): string
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+
+        $sql = <<< SQL
+            SELECT CHARACTER_MAXIMUM_LENGTH 
+            FROM information_schema.COLUMNS 
+            WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'oro_access_role' AND COLUMN_NAME = 'label';
+        SQL;
+
+        $accessTokenScopeLength = $this->connection->executeQuery($sql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        return $accessTokenScopeLength;
+    }
+
+    private function resetDefaultScopeColumnsLength(): void
+    {
+        $this->connection->executeQuery('ALTER TABLE oro_access_role MODIFY label VARCHAR(30) DEFAULT NULL');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
@@ -16,7 +16,7 @@ Akeneo\UserManagement\Component\Model\Role:
             lenght: 30
         label:
             type: string
-            lenght: 30
+            length: 255
         type:
             type: string
             nullable: false


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport from https://akeneo.atlassian.net/browse/PIM-10983

In some old PIMs, the label column of oro_access_role table was set to varchar(30) and during the migration from PaaS to SaaS was not updated to varchar(255) due to some typo in configuration.

This PR fixes the typo and add a simple migration to fix the column size.