### PR TITLE
PIM-11071: Fix potential divided by zero in completeness calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,9 +96,10 @@
 - PIM-11039: Fix export with duplicated labels
 - PIM-10869: Image upload fields now only accept images
 - PIM-11063: Fix validation of generated identifiers
-- PIM-11066: PIM-11066: Fix Missing Values Adder for scopable + localizable + locale specific attributes
+- PIM-11066: Fix Missing Values Adder for scopable + localizable + locale specific attributes
 - PIM-11018: Fix view on Connected App permissions if manage or not
 - PIM-11062: Fix category filter behavior in product grid
+- PIM-11071: Fix potential divided by zero in completeness calculation
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -406,6 +406,9 @@ SQL;
             $completenessesByUuid = [];
             foreach ($completenesses as $channelCode => $completenessByLocale) {
                 foreach ($completenessByLocale as $localeCode => $value) {
+                    if (0 === $value['required']) {
+                        continue;
+                    }
                     $ratio = (int) floor(100 * ($value['required'] - $value['missing']) / $value['required']);
                     $completenessesByUuid[$channelCode][$localeCode] = $ratio;
                 }


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

We suspect that with the former completeness tables (`pim_catalog_completeness`), it was possible to have a zero as value for `required` (number of required attributes).
With the new table (`pim_catalog_product_completeness`), we don't store the data for channels that don't have any required attributes.

But if there were some products with zero required attributes in `pim_catalog_completeness`, then the migration has inserted them in the new table (`pim_catalog_product_completeness`), then this error could happen.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
