### PR TITLE
PIM-11073: Fix search with underscore on attribute grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 - PIM-11018: Fix view on Connected App permissions if manage or not
 - PIM-11062: Fix category filter behavior in product grid
 - PIM-11071: Fix potential divided by zero in completeness calculation
+- PIM-11073: Fix search with underscore on attribute grid
 
 ## Improvements
 

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
@@ -53,7 +53,7 @@ class StringFilterSpec extends ObjectBehavior
         $this->apply($ds, ['type' => 'empty', 'value' => ''])->shouldReturn(true);
     }
 
-    function it_escapes_special_characters(
+    function it_escapes_special_characters_with_like_operator(
         FilterDatasourceAdapterInterface $ds,
         ExpressionBuilderInterface $builder)
     {
@@ -68,5 +68,22 @@ class StringFilterSpec extends ObjectBehavior
         $ds->setParameter('code1877008211', '%fabric\_%')->shouldBeCalled();
 
         $this->apply($ds, ['type' => 1, 'value' => 'fabric_'])->shouldReturn(true);
+    }
+
+    function it_does_not_escape_special_characters_with_equal_operator(
+        FilterDatasourceAdapterInterface $ds,
+        ExpressionBuilderInterface $builder)
+    {
+        $this->init('code', ['data_name' => 'a.code']);
+        $ds->generateParameterName('code')->willReturn('code1877008211');
+        $comparisonExpr = new Expr\Comparison('a.code', '=', ':code1877008211');
+
+        $builder->comparison('a.code', '=', 'code1877008211', true)->willReturn($comparisonExpr);
+        $ds->expr()->willReturn($builder);
+
+        $ds->addRestriction($comparisonExpr, 'AND', false)->shouldBeCalled();
+        $ds->setParameter('code1877008211', 'fabric_')->shouldBeCalled();
+
+        $this->apply($ds, ['type' => 3, 'value' => 'fabric_'])->shouldReturn(true);
     }
 }

--- a/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
@@ -85,7 +85,7 @@ class StringFilter extends OroStringFilter
     /**
      * {@inheritdoc}
      */
-    protected function parseData($data)
+    protected function parseData($data): false|array
     {
         if (!is_array($data) || !array_key_exists('value', $data) || !$data['value']) {
             return false;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We want to escape underscores only when having `%` so LIKE ot NOT LIKE operators.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
