### PR TITLE
PIM-11011: Fix versioning on common attribute values update using no …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - PIM-11071: Fix potential divided by zero in completeness calculation
 - PIM-11073: Fix search with underscore on attribute grid
 - PIM-11035: Modify the command to fit with UCS
+- PIM-11011: Fix versioning on common attribute values update using no real time imports
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -105,11 +105,11 @@ class VersionBuilder
         $oldSnapshot = $previousVersion ? $previousVersion->getSnapshot() : [];
 
         $modification = $pending->getChangeset();
-        $snapshot = $modification + $oldSnapshot;
-        $changeset = $this->buildChangeset($oldSnapshot, $snapshot);
+        $snapshotFromPreviousVersion = \array_replace($modification, $oldSnapshot);
+        $changeset = $this->buildChangeset($oldSnapshot, $snapshotFromPreviousVersion);
 
         $pending->setVersion($versionNumber)
-            ->setSnapshot($snapshot)
+            ->setSnapshot($snapshotFromPreviousVersion)
             ->setChangeset($changeset);
 
         return $pending;

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/Builder/VersionBuilderSpec.php
@@ -68,18 +68,18 @@ class VersionBuilderSpec extends ObjectBehavior
         $this->buildPendingVersion($pending);
     }
 
-    function it_compare_versions(Version $pending, Version $previousPending)
+    function it_compares_versions(Version $pending, Version $previousVersion)
     {
-        $previousPending->getVersion()->willReturn(1);
-        $previousPending->getSnapshot()->willReturn(['test' => '00112233']);
+        $previousVersion->getVersion()->willReturn(1);
+        $previousVersion->getSnapshot()->willReturn(['test' => 'old_data', 'description' => "old description"]);
 
         $pending->setVersion(2)->willReturn($pending);
-        $pending->setSnapshot(['test' => '0112233'])->willReturn($pending);
-        $pending->getChangeset()->willReturn(['test' => '0112233']);
+        $pending->setSnapshot(['test' => 'old_data', "name" => "pending name", "description" => "old description"])->willReturn($pending);
+        $pending->getChangeset()->willReturn(['test' => 'pending_data', "name" => "pending name"]);
 
-        $pending->setChangeset(['test' => ['old' => '00112233', 'new' => '0112233']])->willReturn($pending);
+        $pending->setChangeset(["name" => ["old" => "", "new" => "pending name"]])->willReturn($pending);
 
-        $this->buildPendingVersion($pending, $previousPending);
+        $this->buildPendingVersion($pending, $previousVersion);
     }
 
     /**


### PR DESCRIPTION
…real time imports

**Description (for Contributor and Core Developer)**

When evaluating changeset between two versions, the operator `+` was merging left into right (taking stale data).
`array_merge` merges right into. (which is the newer version in this case)

`$modification + $oldSnapshot `
will result in:

```
description = "Quelles belles chaussures"
```

`array_merge`
will result in:
```
description = Nouvelles belles chaussures
```

So old version was re-applied and there was a difference between the newer version and the old, so the pending version was not removed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
