### PR TITLE
PIM-11088: Catch ElasticSearch exception

### DIFF
--- a/front-packages/shared/src/components/Navigation/PimNavigation.tsx
+++ b/front-packages/shared/src/components/Navigation/PimNavigation.tsx
@@ -54,9 +54,11 @@ const PimNavigation: FC<Props> = ({entries, activeEntryCode, activeSubEntryCode,
 
   useEffect(() => {
     fetch(router.generate('pim_analytics_data_collect')).then(response => {
-      response.json().then(data => {
-        setPimVersion(data);
-      });
+      if (response.ok) {
+        response.json().then(data => {
+          setPimVersion(data);
+        });
+      }
     });
   }, []);
 

--- a/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
+++ b/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
@@ -96,3 +96,30 @@ test('It displays different url according to pim version', async () => {
   fireEvent.mouseLeave(screen.getByText('pim_menu.tab.help.title'));
   expect(screen.getByText('pim_menu.tab.help.help_center')).not.toBeVisible();
 });
+
+test('It displays simple url if pim version is not retrieved', async () => {
+  // @ts-ignore
+  global.fetch = () =>
+    Promise.resolve({
+      ok: false,
+      status: 500,
+    });
+
+  renderWithProviders(
+    <PimNavigation
+      entries={aMainNavigation()}
+      activeEntryCode="entry10"
+      activeSubEntryCode="subentry2"
+      freeTrialEnabled={true}
+    />
+  );
+
+  expect(screen.getByText('pim_menu.tab.help.title')).toBeInTheDocument();
+  fireEvent.mouseOver(screen.getByText('pim_menu.tab.help.title'));
+
+  const helpCenterUrl = screen.getByText('pim_menu.tab.help.help_center');
+
+  await waitFor(() => !!helpCenterUrl);
+  expect(screen.getByText('pim_menu.tab.help.help_center')).toBeVisible();
+  expect(helpCenterUrl).toHaveAttribute('href', 'https://help.akeneo.com');
+});

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/fetcher/Dashboard/fetchKeyIndicators.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/fetcher/Dashboard/fetchKeyIndicators.ts
@@ -15,9 +15,14 @@ const fetchKeyIndicators = async (
     category: categoryCode,
   };
 
-  const response = await fetch(Routing.generate(ROUTE_NAME, routeParams));
+  const url = Routing.generate(ROUTE_NAME, routeParams);
+  try {
+    const response = await fetch(url);
 
-  return await response.json();
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
 };
 
 export {fetchKeyIndicators};

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/public/js/patch-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/public/js/patch-fetcher.js
@@ -14,25 +14,29 @@ define(['jquery', 'underscore', 'pim/data-collector'], function ($, _, DataColle
 
         return deferred.promise();
       } else {
-        return DataCollector.collect('pim_analytics_data_collect').then(function (collectedData) {
-          var version = collectedData.pim_version;
-          var minorVersion = _.first(version.match(/^\d+.\d+/g));
-          var page = collectedData.pim_edition + '-' + minorVersion + '.json';
-          var lastPatchUrl = updateServerUrl + '/' + page;
+        return DataCollector.collect('pim_analytics_data_collect')
+          .then(function (collectedData) {
+            var version = collectedData.pim_version;
+            var minorVersion = _.first(version.match(/^\d+.\d+/g));
+            var page = collectedData.pim_edition + '-' + minorVersion + '.json';
+            var lastPatchUrl = updateServerUrl + '/' + page;
 
-          return $.ajax({
-            dataType: 'json',
-            url: lastPatchUrl,
-            data: collectedData,
-            timeout: 10000,
-          }).then(function (patchData) {
-            var patch = patchData.last_patch.name;
-            var cleanedPatch = patch.replace(/^v/g, '');
-            sessionStorage.setItem(lastPatchKey, cleanedPatch);
+            return $.ajax({
+              dataType: 'json',
+              url: lastPatchUrl,
+              data: collectedData,
+              timeout: 10000,
+            }).then(function (patchData) {
+              var patch = patchData.last_patch.name;
+              var cleanedPatch = patch.replace(/^v/g, '');
+              sessionStorage.setItem(lastPatchKey, cleanedPatch);
 
-            return cleanedPatch;
+              return cleanedPatch;
+            });
+          })
+          .catch(function () {
+            return '';
           });
-        });
       }
     },
   };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/help.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/help.ts
@@ -34,25 +34,29 @@ class Help extends BaseView {
   }
 
   private getUrl(): Promise<string> {
-    return DataCollector.collect(this.analyticsUrl).then((data: any) => {
-      const {pim_version, pim_edition} = data;
+    return DataCollector.collect(this.analyticsUrl)
+      .then((data: any) => {
+        const {pim_version, pim_edition} = data;
 
-      let version = `v${pim_version.split('.')[0]}`;
-      let campaign = `${pim_edition}${pim_version}`;
+        let version = `v${pim_version.split('.')[0]}`;
+        let campaign = `${pim_edition}${pim_version}`;
 
-      // CE master, serenity
-      if (pim_version.split('.').length === 1) {
-        version = 'serenity';
-        campaign = 'serenity';
-      }
+        // CE master, serenity
+        if (pim_version.split('.').length === 1) {
+          version = 'serenity';
+          campaign = 'serenity';
+        }
 
-      const url = new URL(`https://help.akeneo.com/pim/${version}/index.html`);
-      url.searchParams.append('utm_source', 'akeneo-app');
-      url.searchParams.append('utm_medium', 'interrogation-icon');
-      url.searchParams.append('utm_campaign', campaign);
+        const url = new URL(`https://help.akeneo.com/pim/${version}/index.html`);
+        url.searchParams.append('utm_source', 'akeneo-app');
+        url.searchParams.append('utm_medium', 'interrogation-icon');
+        url.searchParams.append('utm_campaign', campaign);
 
-      return url.href;
-    });
+        return url.href;
+      })
+      .catch(function () {
+        return 'https://help.akeneo.com';
+      });
   }
 }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/useDashboardCompleteness.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/useDashboardCompleteness.ts
@@ -9,11 +9,16 @@ const useDashboardCompleteness = (catalogLocale: string): ChannelsLocalesComplet
 
   useEffect(() => {
     (async () => {
-      const result = await fetch(router.generate('pim_dashboard_widget_data', {alias: 'completeness'}), {
-        method: 'GET',
-      });
-      const convertedData = convertBackendDashboardCompletenessData(await result.json(), catalogLocale);
-      setData(convertedData);
+      try {
+        const result = await fetch(router.generate('pim_dashboard_widget_data', {alias: 'completeness'}), {
+          method: 'GET',
+        });
+        const data = await result.json();
+        const convertedData = convertBackendDashboardCompletenessData(data, catalogLocale);
+        setData(convertedData);
+      } catch (error) {
+        setData(null);
+      }
     })();
   }, [catalogLocale]);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When Elasticsearch is down, `/analytics/collect_data` return a **500 internal server error**.
And Navigation bar is not shown
PHP ElasticSearch Client throw _NoNodesAvailableException_

**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
