### PR TITLE
CPM-1155: SKU can be filled at product creation even if the attribute…

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -63,10 +63,6 @@ define([
     },
 
     isReadOnly: async function (identifier) {
-      if (identifier?.is_read_only) {
-        return new Promise(resolve => resolve(true));
-      }
-
       //If we are in CE, the permission registry does not exists so the button is visible
       if (undefined === FetcherRegistry.getFetcher('permission')?.options?.urls) {
         return new Promise(resolve => resolve(false));


### PR DESCRIPTION
… is read only

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
SKU can be filled in the creation of products even if the attribute is read-only, on pop-in creation and duplication

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
