### PR TITLE
SAAS-882 Allow using non default auth in-memory cache implementation …

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
         "openspout/openspout": "^4.9.0",
         "opis/json-schema": "^2.3",
         "phpseclib/phpseclib": "^3.0",
+        "psr/cache": "^1.0.0",
         "psr/event-dispatcher": "^1.0.0",
         "ramsey/uuid": "4.7.1",
         "ramsey/uuid-doctrine": "^1.8",

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
@@ -1,7 +1,7 @@
 services:
     Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\PubSubClientFactory:
         arguments:
-            - '%env(string:SRNT_GOOGLE_APPLICATION_CREDENTIALS)%'
+            $keyFilePath: '%env(string:SRNT_GOOGLE_APPLICATION_CREDENTIALS)%'
 
     Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\GpsTransportFactory:
         arguments:

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub;
 
+use Psr\Cache\CacheItemPoolInterface;
 use Google\Cloud\PubSub\PubSubClient;
 
 /**
@@ -14,21 +15,20 @@ use Google\Cloud\PubSub\PubSubClient;
  */
 class PubSubClientFactory
 {
-    /** @var ?string */
-    private $keyFilePath = null;
+    private array $baseConfig = [];
 
-    public function __construct(string $keyFilePath)
+    public function __construct(string $keyFilePath = null, CacheItemPoolInterface $authCache = null)
     {
         if (!empty($keyFilePath)) {
-            $this->keyFilePath = $keyFilePath;
+            $this->baseConfig['keyFilePath'] = $keyFilePath;
+        }
+        if (!is_null($authCache)) {
+            $this->baseConfig['authCache'] = $authCache;
         }
     }
 
     public function createPubSubClient(array $config): PubSubClient
     {
-        return new PubSubClient(array_merge([
-            'keyFilePath' => $this->keyFilePath,
-            'transport' => 'rest',
-        ], $config));
+        return new PubSubClient(array_merge($this->baseConfig, $config));
     }
 }


### PR DESCRIPTION
### Allow using non default auth in-memory cache implementation for GooglePubSub client.

Will allow adding for exemple an APCu cache to share the access_tokens between FPM processes when using short-lived credentials.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
