### PR TITLE
PIM-11083: [backport] CPM-653: do not sort on _id in ES cursors

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- [Backport CPM-653] PIM-11083: Do not sort on _id in ES cursors
+
 # 6.0.90 (2023-07-06)
 
 - PIM-11070: Increase the oro_access_role label column to VARCHAR(255)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
@@ -85,7 +85,7 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
             return $identifiers;
         }
 
-        $sort = ['_id' => 'asc'];
+        $sort = ['id' => 'asc'];
 
         if (isset($esQuery['sort'])) {
             $sort = array_merge($esQuery['sort'], $sort);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
@@ -108,7 +108,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
             return $identifiers;
         }
 
-        $sort = ['_id' => 'asc'];
+        $sort = ['id' => 'asc'];
 
         if (isset($esQuery['sort'])) {
             $sort = array_merge($esQuery['sort'], $sort);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactory.php
@@ -29,7 +29,7 @@ class FromSizeIdentifierResultCursorFactory implements CursorFactoryInterface
     public function createCursor($esQuery, array $options = [])
     {
         $options = $this->resolveOptions($options);
-        $sort = ['_id' => 'asc'];
+        $sort = ['id' => 'asc'];
 
         $esQuery['track_total_hits'] = true;
         $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactory.php
@@ -31,7 +31,7 @@ class SearchAfterSizeIdentifierResultCursorFactory implements CursorFactoryInter
     public function createCursor($esQuery, array $options = [])
     {
         $options = $this->resolveOptions($options);
-        $sort = ['_id' => 'asc'];
+        $sort = ['id' => 'asc'];
 
         $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type']);
         $esQuery['sort'] = isset($esQuery['sort']) ? array_merge($esQuery['sort'], $sort) : $sort;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/ESGetProductAndProductModelIdentifiersWithValuesIgnoringLocaleAndScope.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/ESGetProductAndProductModelIdentifiersWithValuesIgnoringLocaleAndScope.php
@@ -57,7 +57,7 @@ final class ESGetProductAndProductModelIdentifiersWithValuesIgnoringLocaleAndSco
                     ],
                 ],
             ],
-            'sort' => ['_id' => 'asc'],
+            'sort' => ['id' => 'asc'],
         ];
 
         $searchAfter = null;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorFactorySpec.php
@@ -33,7 +33,7 @@ class CursorFactorySpec extends ObjectBehavior
     function it_creates_a_cursor($searchEngine)
     {
         $searchEngine->search(
-            ['size' => 100, 'sort' => ['_id' => 'asc']]
+            ['size' => 100, 'sort' => ['id' => 'asc']]
         )->willReturn(
             [
                 'hits' => [

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
@@ -27,7 +27,7 @@ class CursorSpec extends ObjectBehavior
 
         $esClient->search([
             'size' => 2,
-            'sort' => ['_id' => 'asc'],
+            'sort' => ['id' => 'asc'],
             'track_total_hits' => true,
         ])
             ->willReturn([
@@ -85,7 +85,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-sub-product-model'],
                 'track_total_hits' => true,
             ])
@@ -107,7 +107,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-product'],
                 'track_total_hits' => true,
             ])->willReturn([
@@ -160,7 +160,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-sub-product-model'],
                 'track_total_hits' => true,
             ])
@@ -182,7 +182,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#foo'],
                 'track_total_hits' => true,
             ])->willReturn([
@@ -242,7 +242,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-sub-product-model'],
                 'track_total_hits' => true,
             ])
@@ -265,7 +265,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 1,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-product'],
                 'track_total_hits' => true,
             ])->willReturn([
@@ -283,7 +283,7 @@ class CursorSpec extends ObjectBehavior
         $esClient->search(
             [
                 'size' => 2,
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-product2'],
                 'track_total_hits' => true,
             ])->willReturn([

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorFactorySpec.php
@@ -35,7 +35,7 @@ class FromSizeCursorFactorySpec extends ObjectBehavior
     function it_creates_a_cursor($searchEngine)
     {
         $searchEngine->search(
-            ['size' => 100, 'sort' => ['_id' => 'asc'], 'from' => 10]
+            ['size' => 100, 'sort' => ['id' => 'asc'], 'from' => 10]
         )->willReturn(
             [
                 'hits' => [

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
@@ -28,7 +28,7 @@ class FromSizeCursorSpec extends ObjectBehavior
         $esClient->search([
             'from' => 0,
             'size' => 2,
-            'sort' => ['_id' => 'asc'],
+            'sort' => ['id' => 'asc'],
             'track_total_hits' => true,
         ])
             ->willReturn([

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
@@ -2,9 +2,9 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ElasticsearchResult;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResultCursor;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ElasticsearchResult;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
@@ -46,7 +46,7 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
         $esClient->search(
             [
-                'sort' => ['_id' => 'asc'],
+                'sort' => ['id' => 'asc'],
                 'query' => [],
                 '_source' => ['identifier', 'document_type'],
                 "track_total_hits" => true,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
@@ -2,9 +2,9 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ElasticsearchResult;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResultCursor;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ElasticsearchResult;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
@@ -47,7 +47,7 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
         $esClient->search(
             [
-                'sort'    => ['_id' => 'asc'],
+                'sort'    => ['id' => 'asc'],
                 'query'   => [],
                 '_source' => ['identifier', 'document_type'],
                 'size'    => 25,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport [CPM-653](https://github.com/akeneo/pim-community-dev/pull/17783)

**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc


[CPM-653]: https://akeneo.atlassian.net/browse/CPM-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OCT-167]: https://akeneo.atlassian.net/browse/OCT-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ