### PR TITLE
CPM-1066: Identifier attribute creation: scopable, localizable and unique fields are readonly

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/identifier.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/identifier.yml
@@ -4,6 +4,39 @@ extensions:
         config:
             template: pim/template/common/drop-zone
 
+    pim-attribute-create-form-properties-common-unique:
+        module: pim/attribute-edit-form/properties/unique
+        parent: pim-attribute-create-form-properties-common
+        targetZone: content
+        position: 120
+        config:
+            fieldName: unique
+            label: pim_enrich.entity.attribute.property.unique
+            readOnly: true
+            defaultValue: true
+
+    pim-attribute-create-form-properties-common-scopable:
+        module: pim/attribute-edit-form/properties/scopable
+        parent: pim-attribute-create-form-properties-common
+        targetZone: content
+        position: 130
+        config:
+            fieldName: scopable
+            label: pim_enrich.entity.attribute.property.scopable
+            readOnly: true
+            defaultValue: false
+
+    pim-attribute-create-form-properties-common-localizable:
+        module: pim/attribute-edit-form/properties/localizable
+        parent: pim-attribute-create-form-properties-common
+        targetZone: content
+        position: 140
+        config:
+            fieldName: localizable
+            label: pim_enrich.entity.attribute.property.localizable
+            readOnly: true
+            defaultValue: false
+
     pim-attribute-identifier-form-type-specific-params:
         module: pim/common/simple-view
         parent: pim-attribute-form-identifier


### PR DESCRIPTION
Before:

![before](https://github.com/akeneo/pim-community-dev/assets/5301298/71831b9f-23fc-4bc3-84b6-83ce37cf2644)

After:

![fixed](https://github.com/akeneo/pim-community-dev/assets/5301298/e2911e93-c66c-4ffe-8e45-af16bba6fc3d)