### PR TITLE
CPM-1157: Fix front query to get main identifier

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/AttributeNormalizer.php
@@ -9,6 +9,7 @@ use Akeneo\Platform\Bundle\UIBundle\Provider\Filter\FilterProviderInterface;
 use Akeneo\Tool\Component\Localization\Localizer\LocalizerInterface;
 use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * Attribute normalizer
@@ -63,6 +64,7 @@ class AttributeNormalizer implements NormalizerInterface, CacheableSupportsMetho
      */
     public function normalize($attribute, $format = null, array $context = [])
     {
+        Assert::isInstanceOf($attribute, AttributeInterface::class);
         $dateMin = null === $attribute->getDateMin() ? null : $attribute->getDateMin()->format('Y-m-d');
         $dateMax = null === $attribute->getDateMax() ? null : $attribute->getDateMax()->format('Y-m-d');
 
@@ -75,6 +77,7 @@ class AttributeNormalizer implements NormalizerInterface, CacheableSupportsMetho
                 'is_locale_specific' => $attribute->isLocaleSpecific(),
                 'date_min'           => $dateMin,
                 'date_max'           => $dateMax,
+                'is_main_identifier' => $attribute->isMainIdentifier(),
             ]
         );
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -16,8 +16,9 @@ define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, 
 
         return this.fetchByTypes([this.options.identifier_type]).then(
           function (attributes) {
-            if (attributes.length > 0) {
-              this.identifierPromise.resolve(attributes[0]).promise();
+            const mainIdentifier = attributes.find(attribute => attribute.is_main_identifier);
+            if (typeof mainIdentifier !== 'undefined') {
+              this.identifierPromise.resolve(mainIdentifier).promise();
 
               return this.identifierPromise;
             }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
@@ -2,7 +2,7 @@
 
 /**
  * This component allows to display an identifier field.
- * It is only displayed when the family contains the identifier attribute.
+ * It is only displayed when the family contains the main identifier attribute.
  *
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -15,7 +15,7 @@ define(['pim/product-edit-form/creation/identifier', 'pim/fetcher-registry'], fu
         return FetcherRegistry.getFetcher('family')
           .fetch(familyCode)
           .then(family => {
-            return !!family.attributes.find(attribute => attribute.type === 'pim_catalog_identifier');
+            return !!family.attributes.find(attribute => attribute.is_main_identifier);
           });
       } else {
         return new Promise(resolve => resolve(false));


### PR DESCRIPTION
Previously, the fetcher returned "any identifier attribute" instead of the main one.
This PR fixes this behavior by adding the notion of "is_main_identifier" in front.