### PR TITLE
CPM-1149: Add button to switch main identifier

### DIFF
--- a/front-packages/shared/src/components/DeleteModal.tsx
+++ b/front-packages/shared/src/components/DeleteModal.tsx
@@ -1,6 +1,7 @@
-import React, {ReactNode, useRef} from 'react';
+import React, {ReactNode, useRef, ReactElement} from 'react';
 import {Button, DeleteIllustration, Modal, useAutoFocus} from 'akeneo-design-system';
 import {useTranslate} from '../hooks';
+import {IllustrationProps} from 'akeneo-design-system/lib/illustrations/IllustrationProps';
 
 type DeleteModalProps = {
   title: string;
@@ -11,6 +12,7 @@ type DeleteModalProps = {
   canConfirmDelete?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
+  illustration?: ReactElement<IllustrationProps>;
 };
 
 const DeleteModal = ({
@@ -22,13 +24,14 @@ const DeleteModal = ({
   canConfirmDelete = true,
   onConfirm,
   onCancel,
+  illustration,
 }: DeleteModalProps) => {
   const translate = useTranslate();
   const cancelRef = useRef(null);
   useAutoFocus(cancelRef);
 
   return (
-    <Modal closeTitle={translate('pim_common.close')} onClose={onCancel} illustration={<DeleteIllustration />}>
+    <Modal closeTitle={translate('pim_common.close')} onClose={onCancel} illustration={illustration ?? <DeleteIllustration />}>
       <Modal.SectionTitle color="brand">{title}</Modal.SectionTitle>
       <Modal.Title>{confirmDeletionTitle ?? translate('pim_common.confirm_deletion')}</Modal.Title>
       {children}

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIdentifierException.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIdentifierException.php
@@ -2,7 +2,10 @@
 
 namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
 
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class CanNotSwitchMainIdentifierException extends \InvalidArgumentException
 {
-
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIdentifierException.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIdentifierException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
+
+class CanNotSwitchMainIdentifierException extends \InvalidArgumentException
+{
+
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIndentifierWithPublishedProductException.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIndentifierWithPublishedProductException.php
@@ -2,6 +2,10 @@
 
 namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
 
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class CanNotSwitchMainIndentifierWithPublishedProductException extends \Exception
 {
     public function __construct()

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIndentifierWithPublishedProductException.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CanNotSwitchMainIndentifierWithPublishedProductException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
+
+class CanNotSwitchMainIndentifierWithPublishedProductException extends \Exception
+{
+    public function __construct()
+    {
+        parent::__construct('If you would like to change your main identifier, please make sure you unpublish your products first and then change your main identifier.');
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CommunityPublishedProductExists.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/CommunityPublishedProductExists.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CommunityPublishedProductExists implements PublishedProductExists
+{
+    public function __invoke(): bool
+    {
+        return false;
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/PublishedProductExists.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/PublishedProductExists.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface PublishedProductExists
+{
+    public function __invoke(): bool;
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/SwitchMainIdentifierValidator.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/SwitchMainIdentifierValidator.php
@@ -19,6 +19,7 @@ final class SwitchMainIdentifierValidator
     public function __construct(
         private readonly AttributeRepositoryInterface $attributeRepository,
         private readonly FeatureFlags $featureFlags,
+        private readonly PublishedProductExists $publishedProductExists,
     ) {
     }
 
@@ -26,6 +27,7 @@ final class SwitchMainIdentifierValidator
         SwitchMainIdentifierCommand $command
     ): void {
         $this->validateOnboarderIsDisabled();
+        $this->validateNoPublishedProducts();
         $this->loadNewMainIdentifier($command->getNewMainIdentifierCode());
         $this->validateAttributeExists();
         $this->validateAttributeIsAnIdentifier();
@@ -80,6 +82,13 @@ final class SwitchMainIdentifierValidator
 
         if ($enabled) {
             throw new \InvalidArgumentException('You cannot set another identifier attribute as the main identifier because this feature is not compatible with Akeneo Onboarder.');
+        }
+    }
+
+    private function validateNoPublishedProducts(): void
+    {
+        if (($this->publishedProductExists)()) {
+            throw new \InvalidArgumentException('If you would like to change your main identifier, please make sure you unpublish your products first and then change your main identifier.');
         }
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/SwitchMainIdentifierValidator.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Application/SwitchMainIdentifier/SwitchMainIdentifierValidator.php
@@ -23,6 +23,10 @@ final class SwitchMainIdentifierValidator
     ) {
     }
 
+    /**
+     * @throws CanNotSwitchMainIndentifierWithPublishedProductException
+     * @throws CanNotSwitchMainIdentifierException
+     */
     public function validate(
         SwitchMainIdentifierCommand $command
     ): void {
@@ -37,7 +41,7 @@ final class SwitchMainIdentifierValidator
     private function validateAttributeExists(): void
     {
         if (null === $this->newMainIdentifier) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new CanNotSwitchMainIdentifierException(sprintf(
                 '%s attribute does not exist',
                 $this->newMainIdentifier
             ));
@@ -48,7 +52,7 @@ final class SwitchMainIdentifierValidator
     {
         Assert::isInstanceOf($this->newMainIdentifier, Attribute::class);
         if ($this->newMainIdentifier->getType() !== AttributeTypes::IDENTIFIER) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new CanNotSwitchMainIdentifierException(sprintf(
                 '%s attribute is not an identifier',
                 $this->newMainIdentifier
             ));
@@ -59,7 +63,7 @@ final class SwitchMainIdentifierValidator
     {
         Assert::isInstanceOf($this->newMainIdentifier, Attribute::class);
         if ($this->newMainIdentifier->isMainIdentifier()) {
-            throw new \InvalidArgumentException(sprintf(
+            throw new CanNotSwitchMainIdentifierException(sprintf(
                 '%s attribute is already the main identifier',
                 $this->newMainIdentifier
             ));
@@ -81,14 +85,14 @@ final class SwitchMainIdentifierValidator
         }
 
         if ($enabled) {
-            throw new \InvalidArgumentException('You cannot set another identifier attribute as the main identifier because this feature is not compatible with Akeneo Onboarder.');
+            throw new CanNotSwitchMainIdentifierException('You cannot set another identifier attribute as the main identifier because this feature is not compatible with Akeneo Onboarder.');
         }
     }
 
     private function validateNoPublishedProducts(): void
     {
         if (($this->publishedProductExists)()) {
-            throw new \InvalidArgumentException('If you would like to change your main identifier, please make sure you unpublish your products first and then change your main identifier.');
+            throw new CanNotSwitchMainIndentifierWithPublishedProductException();
         }
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
@@ -142,3 +142,7 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
             - '@feature_flags'
+            - '@Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier\PublishedProductExists'
+
+    Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier\PublishedProductExists:
+        class: Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier\CommunityPublishedProductExists

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
@@ -141,3 +141,4 @@ services:
     Akeneo\Pim\Structure\Bundle\Application\SwitchMainIdentifier\SwitchMainIdentifierValidator:
         arguments:
             - '@pim_catalog.repository.attribute'
+            - '@feature_flags'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
@@ -56,9 +56,13 @@ type AttributeSetupAppProps = {
 
 type ErrorMessage = {
   exception: 'published_product' | string;
-}
+};
 
-const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainIdentifierAttribute, onMainIdentifierChange}) => {
+const AttributeSetupApp: FC<AttributeSetupAppProps> = ({
+  attribute,
+  originalMainIdentifierAttribute,
+  onMainIdentifierChange,
+}) => {
   const translate = useTranslate();
   const userContext = useUserContext();
   const router = useRouter();
@@ -87,7 +91,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
 
   const redirectToPublishedProducts = () => {
     router.redirectToRoute('pimee_workflow_published_product_index');
-  }
+  };
 
   const setAsMainIdentifier = async () => {
     const response = await fetch(setAsMainIdentifierUrl, {
@@ -109,9 +113,13 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
         if (errorMessage.exception === 'published_product') {
           notify(
             NotificationLevel.ERROR,
-            translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product'),
+            translate(
+              'pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product'
+            ),
             <Link onClick={redirectToPublishedProducts}>
-              {translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product_link')}
+              {translate(
+                'pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product_link'
+              )}
             </Link>
           );
         } else {
@@ -227,7 +235,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
                           {
                             attributeLabel: attributeLabel,
                           }
-                        )}
+                        )}{' '}
                         <Link href={urlMainIdentifier} target="_blank">
                           {translate(
                             'pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.learn_more'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
@@ -51,13 +51,14 @@ const ListCellInner = styled.div`
 type AttributeSetupAppProps = {
   attribute: Attribute;
   originalMainIdentifierAttribute: Attribute;
+  onMainIdentifierChange: () => void;
 };
 
 type ErrorMessage = {
   exception: 'published_product' | string;
 }
 
-const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainIdentifierAttribute}) => {
+const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainIdentifierAttribute, onMainIdentifierChange}) => {
   const translate = useTranslate();
   const userContext = useUserContext();
   const router = useRouter();
@@ -102,6 +103,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
         translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.success')
       );
       setMainIdentifierAttribute(attribute);
+      onMainIdentifierChange();
     } else {
       response.json().then((errorMessage: ErrorMessage) => {
         if (errorMessage.exception === 'published_product') {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
@@ -64,7 +64,8 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
     'https://help.akeneo.com/en_US/serenity-your-first-steps-with-akeneo/serenity-what-is-an-attribute#the-value-per-channel-property';
   const urlLocalizable =
     'https://help.akeneo.com/serenity-your-first-steps-with-akeneo/serenity-what-is-an-attribute#the-value-per-locale-property';
-  const urlMainIdentifier = 'http://todo.com';
+  const urlMainIdentifier =
+    'https://help.akeneo.com/serenity-build-your-catalog/33-serenity-manage-your-product-identifiers';
   const [mainIdentifierAttribute, setMainIdentifierAttribute] = useState<Attribute>(originalMainIdentifierAttribute);
   const isIdentifier = attribute.type === 'pim_catalog_identifier';
   const isMainIdentifier = isIdentifier && mainIdentifierAttribute.code === attribute.code;
@@ -73,6 +74,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
   const attributeLabel = getLabel(attribute.labels, catalogLocale, attribute.code);
   const [isOpen, open, close] = useBooleanState();
   const isOnboarderEnabled = featureFlags.isEnabled('onboarder');
+  const isNotSaved = !('meta' in attribute); // A non saved attribute don't have meta from backend
 
   const setAsMainIdentifierUrl = router.generate('pim_enrich_attribute_rest_switch_main_identifier', {
     attributeCode: attribute.code,
@@ -172,7 +174,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
               </List.RowHelpers>
             )}
             <List.RemoveCell>
-              {isMainIdentifier || isOnboarderEnabled ? (
+              {isMainIdentifier || isOnboarderEnabled || isNotSaved ? (
                 <IconButton ghost="borderless" level="tertiary" icon={<LockIcon />} title="" />
               ) : (
                 <>
@@ -206,6 +208,11 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
                             attributeLabel: attributeLabel,
                           }
                         )}
+                        <Link href={urlMainIdentifier} target="_blank">
+                          {translate(
+                            'pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.learn_more'
+                          )}
+                        </Link>
                       </Helper>
                       {translate(
                         'pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.warning',

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
@@ -72,7 +72,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
   const mainIdentifierLabel = getLabel(mainIdentifierAttribute.labels, catalogLocale, mainIdentifierCode);
   const attributeLabel = getLabel(attribute.labels, catalogLocale, attribute.code);
   const [isOpen, open, close] = useBooleanState();
-  const isOnboarderEnabled = featureFlags.isEnabled('onboarder') || true;
+  const isOnboarderEnabled = featureFlags.isEnabled('onboarder');
 
   const setAsMainIdentifierUrl = router.generate('pim_enrich_attribute_rest_switch_main_identifier', {
     attributeCode: attribute.code,
@@ -93,10 +93,13 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
       );
       setMainIdentifierAttribute(attribute);
     } else {
-      notify(
-        NotificationLevel.ERROR,
-        translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail')
-      );
+      response.json().then(errorMessage => {
+        notify(
+          NotificationLevel.ERROR,
+          `${translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail')}
+          ${errorMessage}`
+        );
+      });
     }
     close();
   };
@@ -169,7 +172,7 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
               </List.RowHelpers>
             )}
             <List.RemoveCell>
-              {isMainIdentifier && !isOnboarderEnabled ? (
+              {isMainIdentifier || isOnboarderEnabled ? (
                 <IconButton ghost="borderless" level="tertiary" icon={<LockIcon />} title="" />
               ) : (
                 <>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/AttributeSetupApp.tsx
@@ -53,6 +53,10 @@ type AttributeSetupAppProps = {
   originalMainIdentifierAttribute: Attribute;
 };
 
+type ErrorMessage = {
+  exception: 'published_product' | string;
+}
+
 const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainIdentifierAttribute}) => {
   const translate = useTranslate();
   const userContext = useUserContext();
@@ -80,6 +84,10 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
     attributeCode: attribute.code,
   });
 
+  const redirectToPublishedProducts = () => {
+    router.redirectToRoute('pimee_workflow_published_product_index');
+  }
+
   const setAsMainIdentifier = async () => {
     const response = await fetch(setAsMainIdentifierUrl, {
       method: 'POST',
@@ -95,12 +103,22 @@ const AttributeSetupApp: FC<AttributeSetupAppProps> = ({attribute, originalMainI
       );
       setMainIdentifierAttribute(attribute);
     } else {
-      response.json().then(errorMessage => {
-        notify(
-          NotificationLevel.ERROR,
-          `${translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail')}
-          ${errorMessage}`
-        );
+      response.json().then((errorMessage: ErrorMessage) => {
+        if (errorMessage.exception === 'published_product') {
+          notify(
+            NotificationLevel.ERROR,
+            translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product'),
+            <Link onClick={redirectToPublishedProducts}>
+              {translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail_published_product_link')}
+            </Link>
+          );
+        } else {
+          notify(
+            NotificationLevel.ERROR,
+            `${translate('pim_enrich.entity.attribute.module.edit.attribute_setup.set_as_main_identifier.flash.fail')}
+            ${errorMessage.exception}`
+          );
+        }
       });
     }
     close();

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
@@ -12,11 +12,13 @@ class AttributeSetup extends BaseView {
   mainIdentifierAttribute: Attribute;
 
   configure(): JQueryPromise<any> {
-    return FetcherRegistry.getFetcher('attribute').getIdentifierAttribute().then((mainIdentifierAttribute: Attribute) => {
-      this.mainIdentifierAttribute = mainIdentifierAttribute;
+    return FetcherRegistry.getFetcher('attribute')
+      .getIdentifierAttribute()
+      .then((mainIdentifierAttribute: Attribute) => {
+        this.mainIdentifierAttribute = mainIdentifierAttribute;
 
-      return super.configure();
-    });
+        return super.configure();
+      });
   }
 
   render(): any {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
@@ -5,14 +5,26 @@ import {pimTheme} from 'akeneo-design-system';
 import {ThemeProvider} from 'styled-components';
 import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
 import {AttributeSetupApp} from './AttributeSetupApp';
+import {Attribute} from '../models/Attribute';
+const FetcherRegistry = require('pim/fetcher-registry');
 
 class AttributeSetup extends BaseView {
+  mainIdentifierAttribute: Attribute;
+
+  configure(): JQueryPromise<any> {
+    return FetcherRegistry.getFetcher('attribute').getIdentifierAttribute().then((mainIdentifierAttribute: Attribute) => {
+      this.mainIdentifierAttribute = mainIdentifierAttribute;
+
+      return super.configure();
+    });
+  }
+
   render(): any {
     const attribute = this.getFormData();
     ReactDOM.render(
       <DependenciesProvider>
         <ThemeProvider theme={pimTheme}>
-          <AttributeSetupApp attribute={attribute} />
+          <AttributeSetupApp attribute={attribute} originalMainIdentifierAttribute={this.mainIdentifierAttribute} />
         </ThemeProvider>
       </DependenciesProvider>,
       this.el

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute/form/attribute-setup.tsx
@@ -6,6 +6,7 @@ import {ThemeProvider} from 'styled-components';
 import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
 import {AttributeSetupApp} from './AttributeSetupApp';
 import {Attribute} from '../models/Attribute';
+
 const FetcherRegistry = require('pim/fetcher-registry');
 
 class AttributeSetup extends BaseView {
@@ -23,10 +24,18 @@ class AttributeSetup extends BaseView {
 
   render(): any {
     const attribute = this.getFormData();
+    const handleMainIdentifierChange = () => {
+      FetcherRegistry.getFetcher('attribute').clear();
+    };
+
     ReactDOM.render(
       <DependenciesProvider>
         <ThemeProvider theme={pimTheme}>
-          <AttributeSetupApp attribute={attribute} originalMainIdentifierAttribute={this.mainIdentifierAttribute} />
+          <AttributeSetupApp
+            attribute={attribute}
+            originalMainIdentifierAttribute={this.mainIdentifierAttribute}
+            onMainIdentifierChange={handleMainIdentifierChange}
+          />
         </ThemeProvider>
       </DependenciesProvider>,
       this.el

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -270,6 +270,8 @@ pim_enrich.entity.attribute:
                     flash:
                         success: Main identifier has successfully been updated.
                         fail: An error occurred during main identifier update.
+                        fail_published_product: If you would like to change your main identifier, please make sure you unpublish your products first and then change your main identifier.
+                        fail_published_product_link: Go to your published products
             validation: Validation parameters
             select_locale: Select your locale
         delete:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -243,6 +243,11 @@ pim_enrich.entity.attribute:
                 non_unique_attribute_title_highlight: not unique
                 unique_helper: The attribute’s value is different for each product. This cannot be modified.
                 non_unique_helper: The same value can be used for this attribute across several products. This cannot be modified.
+                main_identifier_title: This attribute is
+                main_identifier_title_highlight: the main identifier
+                non_main_identifier_title: This attribute is
+                non_main_identifier_title_highlight: not the main identifier
+                main_identifier_helper: You may have a up to {{ maxIdentifiersCount }} identifiers for your products with one being set as the main identifier. The default main identifier is {{ mainIdentifierLabel }}.
                 scopable_attribute_title: This attribute is
                 scopable_attribute_title_highlight: scopable
                 non_scopable_attribute_title: This attribute is
@@ -254,6 +259,15 @@ pim_enrich.entity.attribute:
                 non_localizable_attribute_title_highlight: not localizable
                 localizable_helper: Value per locale determines if an attribute is localizable (different values for different locales) or not (one value for all locales).
                 learn_more: Learn more
+                set_as_main_identifier:
+                    button: Set as main identifier
+                    confirm: Please type "{{ attributeCode }}"
+                    confirm_title: Setting as main identifier will impact all products
+                    are_you_sure: Are you sure you want to set the {{ attributeLabel }} attribute as the main identifier? Learn more in the help center.
+                    warning: "{{ attributeLabel }} is currently set as the main identifier. This change will impact all products."
+                    flash:
+                        success: Main identifier has successfully been updated.
+                        fail: An error occurred during main identifier update.
             validation: Validation parameters
             select_locale: Select your locale
         delete:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -247,7 +247,7 @@ pim_enrich.entity.attribute:
                 main_identifier_title_highlight: the main identifier
                 non_main_identifier_title: This attribute is
                 non_main_identifier_title_highlight: not the main identifier
-                main_identifier_helper: You may have a up to {{ maxIdentifiersCount }} identifiers for your products with one being set as the main identifier. The default main identifier is {{ mainIdentifierLabel }}.
+                main_identifier_helper: You may have up to {{ maxIdentifiersCount }} identifiers for your products with one being set as the main identifier. The current main identifier is {{ mainIdentifierLabel }}.
                 scopable_attribute_title: This attribute is
                 scopable_attribute_title_highlight: scopable
                 non_scopable_attribute_title: This attribute is

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -265,6 +265,7 @@ pim_enrich.entity.attribute:
                     confirm_title: Setting as main identifier will impact all products
                     are_you_sure: Are you sure you want to set the {{ attributeLabel }} attribute as the main identifier? Learn more in the help center.
                     warning: "{{ attributeLabel }} is currently set as the main identifier. This change will impact all products."
+                    onboarder_warning: You cannot set another identifier attribute as the main identifier because this feature is not compatible with Akeneo Onboarder.
                     flash:
                         success: Main identifier has successfully been updated.
                         fail: An error occurred during main identifier update.

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -263,7 +263,8 @@ pim_enrich.entity.attribute:
                     button: Set as main identifier
                     confirm: Please type "{{ attributeCode }}"
                     confirm_title: Setting as main identifier will impact all products
-                    are_you_sure: Are you sure you want to set the {{ attributeLabel }} attribute as the main identifier? Learn more in the help center.
+                    are_you_sure: Are you sure you want to set the {{ attributeLabel }} attribute as the main identifier?
+                    learn_more: Learn more in the help center.
                     warning: "{{ attributeLabel }} is currently set as the main identifier. This change will impact all products."
                     onboarder_warning: You cannot set another identifier attribute as the main identifier because this feature is not compatible with Akeneo Onboarder.
                     flash:


### PR DESCRIPTION
This PR adds a button in the Danger Zone to update the main identifier.
It is only allowed
- If the attribute is an identifier
- If the attribute is not the main identifier
- If onBoarder is not activated (in this case, a warning is displayed and the button is not available)
- If there is no published products (in this case, the user has to fill the modal, then the backend will return a dedicated error message displayed in the front)
