### PR TITLE
CPM-1160: Fix identifier attribute creation limit validation

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Validator/Constraints/IdentifierAttributeCreationLimitValidator.php
+++ b/src/Akeneo/Pim/Structure/Component/Validator/Constraints/IdentifierAttributeCreationLimitValidator.php
@@ -23,17 +23,17 @@ final class IdentifierAttributeCreationLimitValidator extends ConstraintValidato
     ) {
     }
 
-    public function validate($value, Constraint $constraint): void
+    public function validate($attribute, Constraint $constraint): void
     {
         Assert::isInstanceOf($constraint, IdentifierAttributeCreationLimit::class);
-        if (!$value instanceof AttributeInterface) {
+        if (!$attribute instanceof AttributeInterface) {
             return;
         }
-        if (null !== $value->getId()) {
+        if (null !== $attribute->getId() || AttributeTypes::IDENTIFIER !== $attribute->getType()) {
             return;
         }
 
-        if ($this->creationLimit <= \count($this->repository->findBy(['type' => AttributeTypes::IDENTIFIER]))) {
+        if ($this->creationLimit <= \count($this->repository->getAttributeCodesByType(AttributeTypes::IDENTIFIER))) {
             $this->context
                 ->buildViolation($constraint->message, ['{{limit}}' => $this->creationLimit])
                 ->addViolation();


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The validation was triggered for every attribute type, so you couldn't create any attribute once the limit was reached
