### PR TITLE
PIM-11099: Fix regression on filtering products and product models on Identifier containing a dash character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - PIM-11011: Fix versioning on common attribute values update using no real time imports
 - PIM-10676: [Business-Impact] Prevent users in the PIM to remove all 'system' permissions
 - PIM-11095: Make image extension check case insensitive
+- PIM-11099: Fix regression on filtering products and product models on Identifier containing a dash character
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
@@ -14,7 +14,7 @@ use Akeneo\Tool\Component\Elasticsearch\QueryString;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
- * Identifier filter for an Elasticsearch query
+ * Identifier filter for an Elasticsearch query.
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -22,7 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    const IDENTIFIER_KEY = 'identifier';
+    public const IDENTIFIER_KEY = 'identifier';
 
     /**
      * @param array<string> $supportedFields
@@ -56,7 +56,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
     }
 
     /**
-     * Checks the identifier is a string or an array depending on the operator
+     * Checks the identifier is a string or an array depending on the operator.
      *
      * @throws InvalidPropertyTypeException
      */
@@ -70,7 +70,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
     }
 
     /**
-     * Apply the filtering conditions to the search query builder
+     * Apply the filtering conditions to the search query builder.
      */
     protected function applyFilter(string $field, string $operator, mixed $value): void
     {
@@ -89,7 +89,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
             case Operators::STARTS_WITH:
                 $this->searchQueryBuilder->addFilter(
                     $this->buildIdentifierSearchFilter(
-                        QueryString::escapeValue($value) . '*',
+                        QueryString::escapeValue($value).'*',
                         $productDocumentType,
                         $productIdentifierField,
                         $productModelDocumentType,
@@ -102,7 +102,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
             case Operators::CONTAINS:
                 $this->searchQueryBuilder->addFilter(
                     $this->buildIdentifierSearchFilter(
-                        '*' . QueryString::escapeValue($value) . '*',
+                        '*'.QueryString::escapeValue($value).'*',
                         $productDocumentType,
                         $productIdentifierField,
                         $productModelDocumentType,
@@ -114,7 +114,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
 
             case Operators::DOES_NOT_CONTAIN:
                 $this->searchQueryBuilder->addMustNot($this->buildIdentifierSearchFilter(
-                    '*' . QueryString::escapeValue($value) . '*',
+                    '*'.QueryString::escapeValue($value).'*',
                     $productDocumentType,
                     $productIdentifierField,
                     $productModelDocumentType,
@@ -131,7 +131,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
             case Operators::EQUALS:
                 $this->searchQueryBuilder->addFilter(
                     $this->buildIdentifierTermFilter(
-                        QueryString::escapeValue($value),
+                        $value,
                         $productDocumentType,
                         $productIdentifierField,
                         $productModelDocumentType,
@@ -143,7 +143,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
             case Operators::NOT_EQUAL:
                 $this->searchQueryBuilder->addMustNot(
                     $this->buildIdentifierSearchFilter(
-                        QueryString::escapeValue($value),
+                        $value,
                         $productDocumentType,
                         $productIdentifierField,
                         $productModelDocumentType,
@@ -225,7 +225,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                     [
                         'query_string' => [
                             'default_field' => $productIdentifierField,
-                            'query'         => $searchString,
+                            'query' => $searchString,
                         ],
                     ],
                 ],
@@ -243,7 +243,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                     [
                         'query_string' => [
                             'default_field' => $productModelIdentifierField,
-                            'query'         => $searchString,
+                            'query' => $searchString,
                         ],
                     ],
                 ],
@@ -271,13 +271,13 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                     [
                         'term' => [
                             'document_type' => $productDocumentType,
-                        ]
+                        ],
                     ],
                     [
                         'terms' => [
                             $productIdentifierField => $value,
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -320,13 +320,13 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                     [
                         'term' => [
                             'document_type' => $productDocumentType,
-                        ]
+                        ],
                     ],
                     [
                         'term' => [
                             $productIdentifierField => $value,
-                        ]
-                    ]
+                        ],
+                    ],
                 ],
             ],
         ];
@@ -375,7 +375,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                                 ],
                                 [
                                     'exists' => ['field' => $productIdentifierField],
-                                ]
+                                ],
                             ],
                         ],
                     ],
@@ -389,7 +389,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
                                 ],
                                 [
                                     'exists' => ['field' => $productModelIdentifierField],
-                                ]
+                                ],
                             ],
                         ],
                     ],

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
@@ -28,6 +28,7 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->createProduct('baz', []);
         $this->createProduct('BARISTA', []);
         $this->createProduct('BAZAR', []);
+        $this->createProduct('foo-bar', []);
     }
 
     public function testOperatorStartsWith()
@@ -48,16 +49,16 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
     public function testOperatorContains()
     {
         $result = $this->executeFilter([['identifier', Operators::CONTAINS, 'a']]);
-        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['identifier', Operators::CONTAINS, 'A']]);
-        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::CONTAINS, 'a']]);
-        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::CONTAINS, 'A']]);
-        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
     }
 
     public function testOperatorNotContains()
@@ -86,44 +87,50 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
         $result = $this->executeFilter([['identifier', Operators::EQUALS, 'bazz']]);
         $this->assert($result, []);
 
+        $result = $this->executeFilter([['identifier', Operators::EQUALS, 'foo-bar']]);
+        $this->assert($result, ['foo-bar']);
+
         $result = $this->executeFilter([['sku', Operators::EQUALS, 'bazz']]);
         $this->assert($result, []);
 
         $result = $this->executeFilter([['sku', Operators::EQUALS, 'bAz']]);
         $this->assert($result, ['baz']);
+
+        $result = $this->executeFilter([['sku', Operators::EQUALS, 'foo-bar']]);
+        $this->assert($result, ['foo-bar']);
     }
 
     public function testOperatorNotEquals()
     {
         $result = $this->executeFilter([['identifier', Operators::NOT_EQUAL, 'bazz']]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['identifier', Operators::NOT_EQUAL, 'baz']]);
-        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['identifier', Operators::NOT_EQUAL, 'bAz']]);
-        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::NOT_EQUAL, 'bazz']]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::NOT_EQUAL, 'baz']]);
-        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::NOT_EQUAL, 'bAz']]);
-        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'BARISTA', 'BAZAR', 'foo-bar']);
     }
 
     public function testOperatorInList()
     {
-        $result = $this->executeFilter([['identifier', Operators::IN_LIST, ['baz', 'FOO']]]);
-        $this->assert($result, ['foo', 'baz']);
+        $result = $this->executeFilter([['identifier', Operators::IN_LIST, ['baz', 'FOO', 'foo-bar']]]);
+        $this->assert($result, ['foo', 'baz', 'foo-bar']);
 
         $result = $this->executeFilter([['identifier', Operators::IN_LIST, ['bazz', 'FOOO']]]);
         $this->assert($result, []);
 
-        $result = $this->executeFilter([['sku', Operators::IN_LIST, ['baz', 'FOO']]]);
-        $this->assert($result, ['foo', 'baz']);
+        $result = $this->executeFilter([['sku', Operators::IN_LIST, ['baz', 'FOO', 'foo-bar']]]);
+        $this->assert($result, ['foo', 'baz', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::IN_LIST, ['BAZZ', 'FOOO']]]);
         $this->assert($result, []);
@@ -132,25 +139,25 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
     public function testOperatorNotInList()
     {
         $result = $this->executeFilter([['identifier', Operators::NOT_IN_LIST, ['baz', 'FOO']]]);
-        $this->assert($result, ['bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['identifier', Operators::NOT_IN_LIST, ['bazz', 'FOOO']]]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::NOT_IN_LIST, ['baz', 'FOO']]]);
-        $this->assert($result, ['bar', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['bar', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::NOT_IN_LIST, ['BAZZ', 'FOOO']]]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
     }
 
     public function testOperatorNotEmpty()
     {
         $result = $this->executeFilter([['identifier', Operators::IS_NOT_EMPTY, null]]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
 
         $result = $this->executeFilter([['sku', Operators::IS_NOT_EMPTY, null]]);
-        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR']);
+        $this->assert($result, ['foo', 'bar', 'baz', 'BARISTA', 'BAZAR', 'foo-bar']);
     }
 
     public function testOperatorEmpty()

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
@@ -111,7 +111,7 @@ class IdentifierFilterSpec extends ObjectBehavior
     function it_adds_a_field_filter_with_operator_equals(SearchQueryBuilder $sqb)
     {
         $sqb->addFilter(
-            ["bool" => ["should" => [["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface"]], ["term" => ["values.sku-text.<all_channels>.<all_locales>" => "sku\-001"]]]]], ["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface"]], ["term" => ["identifier" => "sku\-001"]]]]]], "minimum_should_match" => 1]]
+            ["bool" => ["should" => [["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface"]], ["term" => ["values.sku-text.<all_channels>.<all_locales>" => "sku-001"]]]]], ["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface"]], ["term" => ["identifier" => "sku-001"]]]]]], "minimum_should_match" => 1]]
         )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
@@ -121,7 +121,7 @@ class IdentifierFilterSpec extends ObjectBehavior
     function it_adds_a_field_filter_with_operator_not_equal(SearchQueryBuilder $sqb)
     {
         $sqb->addMustNot(
-            ["bool" => ["should" => [["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface"]], ["query_string" => ["default_field" => "values.sku-text.<all_channels>.<all_locales>", "query" => "sku\-001"]]]]], ["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface"]], ["query_string" => ["default_field" => "identifier", "query" => "sku\-001"]]]]]], "minimum_should_match" => 1]]
+            ["bool" => ["should" => [["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface"]], ["query_string" => ["default_field" => "values.sku-text.<all_channels>.<all_locales>", "query" => "sku-001"]]]]], ["bool" => ["filter" => [["term" => ["document_type" => "Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface"]], ["query_string" => ["default_field" => "identifier", "query" => "sku-001"]]]]]], "minimum_should_match" => 1]]
         )->shouldBeCalled();
 
         $sqb->addFilter(


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We remove the Query String escaping on Identifier filter when the equals or not equal operators are used

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
