### PR TITLE
Avoid hydrating entities when counting from ES cursors

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
@@ -23,6 +23,7 @@ abstract class AbstractCursor implements CursorInterface
     protected Client $esClient;
     protected ProductRepositoryInterface $productRepository;
     protected ProductModelRepositoryInterface $productModelRepository;
+    protected array $esQuery;
     protected ?array $items = null;
     protected ?int $count = null;
     protected int $position = 0;
@@ -68,8 +69,11 @@ abstract class AbstractCursor implements CursorInterface
      */
     public function count(): int
     {
-        if (null === $this->items) {
-            $this->rewind();
+        if (null === $this->count) {
+            $esQuery = \array_replace($this->esQuery, ['track_total_hits' => true]);
+
+            $response = $this->esClient->search($esQuery);
+            $this->count = $response['hits']['total']['value'];
         }
 
         return $this->count;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
@@ -31,12 +31,13 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
         Client $esClient,
         ProductRepositoryInterface $productRepository,
         ProductModelRepositoryInterface $productModelRepository,
-        private array $esQuery,
+        array $esQuery,
         private int $pageSize
     ) {
         $this->esClient = $esClient;
         $this->productRepository = $productRepository;
         $this->productModelRepository = $productModelRepository;
+        $this->esQuery = $esQuery;
     }
 
     /**
@@ -82,7 +83,6 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
         }
 
         $esQuery['sort'] = $sort;
-        $esQuery['track_total_hits'] = true;
 
         if (!empty($this->searchAfter)) {
             $esQuery['search_after'] = $this->searchAfter;
@@ -90,7 +90,6 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
 
         $response = $this->esClient->search($esQuery);
         $this->result = new ElasticsearchResult($response);
-        $this->count = $response['hits']['total']['value'];
 
         foreach ($response['hits']['hits'] as $hit) {
             $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
@@ -28,7 +28,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         Client $esClient,
         ProductRepositoryInterface $productRepository,
         ProductModelRepositoryInterface $productModelRepository,
-        private array $esQuery,
+        array $esQuery,
         private int $pageSize,
         private int $limit,
         private int $from = 0
@@ -36,6 +36,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         $this->esClient = $esClient;
         $this->productRepository = $productRepository;
         $this->productModelRepository = $productModelRepository;
+        $this->esQuery = $esQuery;
         $this->initialFrom = $from;
         $this->to = $this->from + $this->limit;
     }
@@ -86,10 +87,8 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
 
         $esQuery['sort'] = $sort;
         $esQuery['from'] = $this->from;
-        $esQuery['track_total_hits'] = true;
 
         $response = $this->esClient->search($esQuery);
-        $this->count = $response['hits']['total']['value'];
 
         foreach ($response['hits']['hits'] as $hit) {
             $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
@@ -38,24 +38,14 @@ class CursorSpec extends ObjectBehavior
 
     function it_is_countable(
         Client $esClient,
-        ProductRepositoryInterface $productRepository,
-        ProductModelRepositoryInterface $productModelRepository,
     ) {
         $this->shouldImplement(\Countable::class);
         $simpleUuid = Uuid::uuid4();
-        $simpleProduct = new Product($simpleUuid);
         $variantUuid = Uuid::uuid4();
         $variantProduct = new Product($variantUuid);
         $variantProduct->setIdentifier('a-variant-product');
 
-        $productRepository->getItemsFromUuids([$variantUuid->toString(), $simpleUuid->toString()])->shouldBeCalled()->willReturn(
-            [$simpleProduct, $variantProduct]
-        );
-        $productModelRepository->getItemsFromIdentifiers([])->shouldBeCalled()->willReturn([]);
-
         $esClient->search([
-            'size' => 2,
-            'sort' => ['id' => 'asc'],
             'track_total_hits' => true,
         ])->shouldBeCalled()->willReturn([
             'hits' => [
@@ -115,7 +105,6 @@ class CursorSpec extends ObjectBehavior
         $esClient->search([
             'size' => 2,
             'sort' => ['id' => 'asc'],
-            'track_total_hits' => true,
         ])->shouldBeCalled()->willReturn([
             'hits' => [
                 'total' => ['value' => 4, 'relation' => 'eq'],
@@ -143,7 +132,6 @@ class CursorSpec extends ObjectBehavior
             'size' => 2,
             'sort' => ['id' => 'asc'],
             'search_after' => ['#a-sub-product-model'],
-            'track_total_hits' => true,
         ])->shouldBeCalled()->willReturn([
             'hits' => [
                 'total' => ['value' => 4, 'relation' => 'eq'],
@@ -172,7 +160,6 @@ class CursorSpec extends ObjectBehavior
                 'size' => 2,
                 'sort' => ['id' => 'asc'],
                 'search_after' => ['#a-root-product-model'],
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [
@@ -224,7 +211,6 @@ class CursorSpec extends ObjectBehavior
             [
                 'size' => 2,
                 'sort' => ['id' => 'asc'],
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [
@@ -246,7 +232,6 @@ class CursorSpec extends ObjectBehavior
                 'size' => 1,
                 'sort' => ['id' => 'asc'],
                 'search_after' => ['#product_' . $nonExistingUuid->toString()],
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [
@@ -264,7 +249,6 @@ class CursorSpec extends ObjectBehavior
                 'size' => 2,
                 'sort' => ['id' => 'asc'],
                 'search_after' => ['#product_model_55'],
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [
@@ -286,7 +270,6 @@ class CursorSpec extends ObjectBehavior
                 'size' => 2,
                 'sort' => ['id' => 'asc'],
                 'search_after' => ['#product_' . $simpleUuid->toString()],
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
@@ -40,18 +40,9 @@ class FromSizeCursorSpec extends ObjectBehavior
 
     function it_is_countable(
         Client $esClient,
-        ProductRepositoryInterface $productRepository,
-        ProductModelRepositoryInterface $productModelRepository,
     ) {
         $this->shouldImplement(\Countable::class);
-        $productRepository->getItemsFromUuids([])
-            ->shouldBeCalledOnce()->willReturn([]);
-        $productModelRepository->getItemsFromIdentifiers(['a-root-product-model', 'a-sub-product-model'])
-            ->shouldBeCalledOnce()->willReturn([]);
         $esClient->search([
-            'from' => 0,
-            'size' => 20,
-            'sort' => ['id' => 'asc'],
             'track_total_hits' => true,
         ])->shouldBeCalledOnce()->willReturn([
             'hits' => [
@@ -97,7 +88,6 @@ class FromSizeCursorSpec extends ObjectBehavior
                 'size' => 20,
                 'sort' => ['id' => 'asc'],
                 'from' => 0,
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [
@@ -132,7 +122,6 @@ class FromSizeCursorSpec extends ObjectBehavior
                 'size' => 16,
                 'sort' => ['id' => 'asc'],
                 'from' => 4,
-                'track_total_hits' => true,
             ]
         )->shouldBeCalled()->willReturn([
             'hits' => [


### PR DESCRIPTION
**Orignal issue**
When trying to count products for a Supplier Portal use case, we noticed that the product repo injected in ES cursors is called to hydrate found entities even just for counting.
In EE, the repo is decorated and also [applies permissions by side effect](https://github.com/akeneo/pim-enterprise-dev/blob/master/src/Akeneo/Pim/Permission/Bundle/Persistence/ORM/EntityWithValue/ProductRepository.php#L248).

**Why it's useless**
- Permissions are [already applied in the ES query by the PQB](https://github.com/akeneo/pim-enterprise-dev/blob/master/src/Akeneo/Pim/Permission/Bundle/Persistence/ORM/EntityWithValue/ProductQueryBuilderFactory.php#L68-L70).
- Other operations done when calling `rewind()` from `count()` concern only pagination and sorting, which are irrelevant when counting.

**Proposed solution**
Stop relying on the call to `rewind()` to populate the count result by a very hidden and implicit side effect (3 nested method calls needed), and dedicate a call to the ES client for counting.

Bonus: counting entities should be more efficient.