### PR TITLE
JEL: add request timeout

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
@@ -29,6 +29,7 @@ class PubSubClientFactory
         return new PubSubClient(array_merge([
             'keyFilePath' => $this->keyFilePath,
             'transport' => 'rest',
+            'requestTimeout' => 30,
         ], $config));
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Add request timeout when we contact PubSub.
We are experiencing some "dead" pods, infinite request can be a reason.

From the PubSub lib, there is a default timeout for GRPC (60 seconds), not for REST. Here we force a timeout to have it in any cases