### PR TITLE
CPM-1165: Visualize main identifier in associations

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -6,9 +6,7 @@ use Akeneo\Category\Infrastructure\Component\Classification\Model\CategoryInterf
 use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\EntityWithQuantifiedAssociationTrait;
 use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociationCollection;
-use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\IdentifierValueInterface;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollection.php
@@ -90,7 +90,7 @@ class QuantifiedAssociationCollection
                 Assert::keyExists($productAssociation, 'id');
                 Assert::keyExists($productAssociation, 'quantity');
 
-                if (isset($productAssociation['id']) && $mappedProductIds->hasIdentifierFromId($productAssociation['id'])) {
+                if (isset($productAssociation['id']) && $mappedProductIds->hasUuidFromId($productAssociation['id'])) {
                     $quantifiedLink = QuantifiedLink::fromUuid(
                         $mappedProductIds->getUuidFromId($productAssociation['id']),
                         $mappedProductIds->getIdentifierFromId($productAssociation['id']),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/UuidMapping.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/UuidMapping.php
@@ -117,8 +117,8 @@ final class UuidMapping
         return $this->idsToIdentifiers[$id] ?? null;
     }
 
-    public function hasUuidFromUuid(string $uuid): bool
+    public function hasUuidFromId(int $id): bool
     {
-        return array_key_exists($uuid, $this->uuidsToIds);
+        return isset($this->idsToUuids[$id]);
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associated-product-row.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associated-product-row.js
@@ -38,14 +38,14 @@ define([
      */
     getTemplateOptions() {
       const isProductModel = this.isProductModel();
-      const label = this.model.get('label');
-      const canRemoveAssociation = this.canRemoveAssociation();
       const id = this.model.id.replace(/product-model-|product-/g, '');
+      const label = this.model.get('label') || `[${id}]`;
+      const canRemoveAssociation = this.canRemoveAssociation();
 
       return {
         useLayerStyle: isProductModel,
         label,
-        identifier: this.model.get('identifier'),
+        identifier: this.model.get('identifier') ?? `[${id}]`,
         imagePath: this.getThumbnailImagePath(),
         canRemoveAssociation,
         redirectUrl: router.generate(

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-and-product-model-picker.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/product-and-product-model-picker.js
@@ -29,7 +29,7 @@ define(['underscore', 'pim/common/item-picker', 'pim/media-url-generator'], func
      */
     selectModel: function (model) {
       this.addItem({
-        id: model.get('identifier'),
+        id: model.get('identifier') ?? `[${model.get('technical_id')}]`,
         itemCode: `${model.get('document_type')};${model.get('id')}`,
         document_type: model.get('document_type'),
         technical_id: model.get('technical_id'),
@@ -149,7 +149,7 @@ define(['underscore', 'pim/common/item-picker', 'pim/media-url-generator'], func
     /**
      * {@inheritdoc}
      */
-    labelMethod: item => item.label,
+    labelMethod: item => item.label ?? `[${item.id}]`,
 
     /**
      * {@inheritdoc}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Group;
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelAssociation;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
@@ -25,7 +24,6 @@ use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Ramsey\Uuid\UuidInterface;
 
 class ProductSpec extends ObjectBehavior


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the association screens (association grid and associated product picker), Display product uuid as fallback when neither the label or main identifier is filled:
![Screenshot from 2023-07-19 09-58-10](https://github.com/akeneo/pim-community-dev/assets/5301298/1e3d35b0-7e4d-48d2-b542-afe9b4ba05fc)
![Screenshot from 2023-07-19 16-33-19](https://github.com/akeneo/pim-community-dev/assets/5301298/7e6caa27-dbec-4d52-9fe0-86cc63339218)



**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
