### PR TITLE
RAB-1541: Do not make the File required on LaunchJobInstanceCommand ServiceApi

### DIFF
--- a/src/Akeneo/Platform/Job/back/Application/LaunchJobInstance/LaunchJobInstanceHandler.php
+++ b/src/Akeneo/Platform/Job/back/Application/LaunchJobInstance/LaunchJobInstanceHandler.php
@@ -24,14 +24,14 @@ class LaunchJobInstanceHandler implements LaunchJobInstanceHandlerInterface
         $code = $launchJobInstanceCommand->code;
         $file = $launchJobInstanceCommand->file;
 
-        $filePath = $this->jobFileStorer->store($code, $file->getFileName(), $file->getResource());
-        $jobConfig = [
-            'storage' => [
+        $jobConfig = ['is_user_authenticated' => true];
+        if (null !== $file) {
+            $filePath = $this->jobFileStorer->store($code, $file->getFileName(), $file->getResource());
+            $jobConfig['storage'] = [
                 'type' => ManualUploadStorage::TYPE,
                 'file_path' => $filePath,
-            ],
-            'is_user_authenticated' => true,
-        ];
+            ];
+        }
 
         $username = $this->tokenStorage->getToken()?->getUser()?->getUserIdentifier();
 

--- a/src/Akeneo/Platform/Job/back/ServiceApi/JobInstance/LaunchJobInstanceCommand.php
+++ b/src/Akeneo/Platform/Job/back/ServiceApi/JobInstance/LaunchJobInstanceCommand.php
@@ -12,7 +12,7 @@ class LaunchJobInstanceCommand
 {
     public function __construct(
         public string $code,
-        public File $file,
+        public ?File $file = null,
     ) {
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I made the File parameter on LaunchJobInstanceCommand not required in order to work with export job type. This parameters is only required when job is import

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
