### PR TITLE
Fix the node docker image generated by CI is the wrong version as CE master is now in 18

### DIFF
--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -548,15 +548,15 @@ jobs:
                       docker run --rm akeneo/pim-php-dev:8.1 php -v
             - run:
                   name: Build Akeneo Node image
-                  command: docker build -t akeneo/node:16 -f docker/Dockerfile_node .
+                  command: docker build -t akeneo/node:18 -f docker/Dockerfile_node .
             - run:
                   name: Display Node and Yarn versions
                   command: |
-                      docker run --rm akeneo/node:16 node --version
-                      docker run --rm akeneo/node:16 yarn --version
+                      docker run --rm akeneo/node:18 node --version
+                      docker run --rm akeneo/node:18 yarn --version
             - run:
                   name: Push images to Dockerhub
                   command: |
                       docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PWD"
                       docker push akeneo/pim-php-dev:8.1
-                      docker push akeneo/node:16
+                      docker push akeneo/node:18


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Actually the node image of Akeneo is 18 (https://github.com/akeneo/pim-community-dev/blob/cf8e24b6eda65ea2123a0822800ee095bc2c42b4/docker/Dockerfile_node) but we tag the image as akeneo/node:16 in Dockerhub, in this PR, i fixed it by taging this image as akeneo/node:18.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
