### PR TITLE
PIM-11200: Fix versinoning on table attributes

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,7 @@
 # 7.0.x
 
+- PIM-11200: Fix versioning on table attribute in case of column reordering
+
 # 7.0.31 (2023-09-25)
 
 # 7.0.30 (2023-09-25)


### PR DESCRIPTION
# How to reproduce

How to reproduce the bug
- Create a product with a table attribute
- Save a table value in this product, with the order coming from the UI (still the same)
- Update this product table value through API, by changing the column order
- Update this product again in any other value
- A new version is created, including the table value

# The issue

The issue comes from the VersionBuilder. This VersionBuilder creates "changeset" (the changes of the new product regarding the previous version of the product.
For each value, we compare strings to strings (for attributes and properties). If `old !== new`, then the value is considered as updated.
As the string `"[{a: "a", b:"b"}]"` differs from `"[{b:"b", a: "a"}]"`, a new version is created.

# The fix

We use 
- `\json_decode` to decode the string. If the string was previously a string, no changed are made. In the case of a table attribute, it will create an array of associative arrays.
- We use `!=` instead of `!==`. Indeed, with triple equals, 2 arrays are not the same if the key order is not the same. With double equals, the key order is not important.