### PR TITLE
PIM-11195: Fix paste scroll with summernote and Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - PIM-11099: Fix regression on filtering products and product models on Identifier containing a dash character
 - PIM-11103: Fix deletion of enriched category attribute when deleting attribute
 - PIM-11101: Prevent user to save bad locale code format (upper/lower : aa_AA)
+- PIM-11195: Fix paste scroll with summernote and Firefox
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/summernote/summernote.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/summernote/summernote.js
@@ -148,6 +148,7 @@
 
   var userAgent = navigator.userAgent;
   var isMSIE = /MSIE|Trident/i.test(userAgent);
+  var isFF = /firefox/i.test(userAgent);
   var browserVersion;
   if (isMSIE) {
     var matches = /MSIE (\d+[.]\d+)/.exec(userAgent);
@@ -155,6 +156,12 @@
       browserVersion = parseFloat(matches[1]);
     }
     matches = /Trident\/.*rv:([0-9]{1,}[\.0-9]{0,})/.exec(userAgent);
+    if (matches) {
+      browserVersion = parseFloat(matches[1]);
+    }
+  }
+  if (isFF) {
+    var matches = /Firefox\/(\d+[.]\d+)/.exec(userAgent);
     if (matches) {
       browserVersion = parseFloat(matches[1]);
     }
@@ -5124,7 +5131,7 @@
       // [workaround] getting image from clipboard
       //  - IE11 and Firefox: CTRL+v hook
       //  - Webkit: event.clipboardData
-      if ((agent.isMSIE && agent.browserVersion > 10) || agent.isFF) {
+      if ((agent.isMSIE && agent.browserVersion > 10) || (agent.isFF && agent.browserVersion < 22)) {
         $paste = $('<div />').attr('contenteditable', true).css({
           position : 'absolute',
           left : -100000,


### PR DESCRIPTION
A hack was done by summernote to fix old versions of FireFox.
Since FF22, this behavior is native.