### PR TITLE
PIM-11212: Fix error handling in mass associate bulk action

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11212: Fix error handling in mass associate bulk action
+
 # 7.0.33 (2023-10-11)
 
 # 7.0.32 (2023-09-27)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/readers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/readers.yml
@@ -114,15 +114,19 @@ services:
     pim_enrich.reader.database.product_and_product_model:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Reader\Database\MassEdit\ProductAndProductModelReader'
         arguments:
-            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_identifier_query_builder_factory'
             - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
             - true
 
     pim_enrich.reader.database.grouped_product_and_product_model:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Reader\Database\MassEdit\ProductAndProductModelReader'
         arguments:
-            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_identifier_query_builder_factory'
             - '@pim_catalog.repository.channel'
+            - '@pim_catalog.repository.product'
+            - '@pim_catalog.repository.product_model'
             - false
 
     pim_enrich.reader.database.products_and_variant_products_of_product_models:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/steps.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/steps.yml
@@ -430,7 +430,7 @@ services:
             - '@pim_enrich.reader.database.grouped_product_and_product_model'
             - '@pim_enrich.connector.processor.mass_edit.product.add_value'
             - '@pim_enrich.writer.database.product_and_product_model_writer'
-            - '%pim_job_product_batch_size%'
+            - 1
             - '@akeneo_batch.job.job_stopper'
 
     pim_enrich.step.edit_common_attributes.mass_edit:

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Reader/Database/MassEdit/ProductAndProductModelReaderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Reader/Database/MassEdit/ProductAndProductModelReaderSpec.php
@@ -4,68 +4,61 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Reader
 
 use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
 use Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Reader\Database\MassEdit\ProductAndProductModelReader;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Promise\ReturnPromise;
 
 class ProductAndProductModelReaderSpec extends ObjectBehavior
 {
     function it_is_initializable(
         ProductQueryBuilderFactoryInterface $pqbFactory,
-        ChannelRepositoryInterface $channelRepository
+        ChannelRepositoryInterface $channelRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository,
     ) {
         $this->beConstructedWith(
             $pqbFactory,
             $channelRepository,
-            true
+            $productRepository,
+            $productModelRepository,
+            false
         );
 
         $this->shouldHaveType(ProductAndProductModelReader::class);
-    }
-
-    function it_sets_step_execution(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        ChannelRepositoryInterface $channelRepository,
-        StepExecution $stepExecution
-    ) {
-        $this->beConstructedWith(
-            $pqbFactory,
-            $channelRepository,
-            true
-        );
-
-        $this->setStepExecution($stepExecution)->shouldReturn(null);
+        $this->shouldImplement(StepExecutionAwareInterface::class);
     }
 
     function it_reads_products_and_product_models(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository,
         StepExecution $stepExecution,
+        JobParameters $jobParameters,
         ChannelInterface $channel,
         ProductQueryBuilderInterface $pqb,
-        CursorInterface $cursor,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2,
-        ProductModelInterface $productModel3,
         ProductInterface $product1,
         ProductInterface $product2,
-        ProductInterface $product3,
-        JobParameters $jobParameters
     ) {
         $this->beConstructedWith(
             $pqbFactory,
             $channelRepository,
+            $productRepository,
+            $productModelRepository,
             false
         );
-
-        $this->setStepExecution($stepExecution);
         $filters = [
             'data' => [
                 [
@@ -86,141 +79,117 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
                 'locales' => ['fr_FR', 'en_US'],
             ],
         ];
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->get('filters')->willReturn($filters);
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $this->setStepExecution($stepExecution);
 
-        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCode()->willReturn('mobile');
+        $channelRepository->findOneByIdentifier('mobile')->shouldBeCalled()->willReturn($channel);
 
         $pqbFactory->create(['filters' => $filters['data'], 'default_scope' => 'mobile'])
-            ->shouldBeCalled()
-            ->willReturn($pqb);
-        $pqb->execute()
-            ->shouldBeCalled()
-            ->willReturn($cursor);
+            ->shouldBeCalled()->willReturn($pqb);
 
-        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
-        $productsCount = count($products);
-        $cursor->valid()->will(
-            function () use (&$productsCount) {
-                return $productsCount-- > 0;
-            }
-        );
-        $cursor->current()->will(new ReturnPromise($products));
-        $cursor->next()->shouldBeCalledTimes(5);
+        $results = [
+            new IdentifierResult('pm_1', ProductModelInterface::class, 'product_model_42'),
+            new IdentifierResult('product_first', ProductInterface::class, 'product_e95ac0d2-a746-4d1a-a3c0-56c7bf48de7d'),
+            new IdentifierResult('pm_2', ProductModelInterface::class, 'product_model_100'),
+            new IdentifierResult('pm_deleted', ProductModelInterface::class, 'product_model_404'),
+            new IdentifierResult('product_deleted', ProductInterface::class, 'product_220c60fb-936f-4dd5-9fc9-99a032c529a9'),
+            new IdentifierResult(null, ProductInterface::class, 'product_b918a5b8-0d0e-44df-b14a-45c88a5350c9'),
+        ];
+        $cursor = new class extends \ArrayIterator implements CursorInterface{};
+        $pqb->execute()->shouldBeCalled()->willReturn(new $cursor($results));
 
-        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(6);
+        $productModelRepository->findOneByIdentifier('pm_1')->shouldBeCalled()->willReturn($productModel1);
+        $productRepository->findOneBy(['uuid' => 'e95ac0d2-a746-4d1a-a3c0-56c7bf48de7d'])->shouldBeCalled()->willReturn($product1);
+        $productModelRepository->findOneByIdentifier('pm_2')->shouldBeCalled()->willReturn($productModel2);
+        $productModelRepository->findOneByIdentifier('pm_deleted')->shouldBeCalled()->willReturn(null);
+        $productRepository->findOneBy(['uuid' => '220c60fb-936f-4dd5-9fc9-99a032c529a9'])->shouldBeCalled()->willReturn(null);
+        $productRepository->findOneBy(['uuid' => 'b918a5b8-0d0e-44df-b14a-45c88a5350c9'])->shouldBeCalled()->willReturn($product2);
 
-        $productModel1->getCode()->willReturn('product_model_1');
-        $productModel2->getCode()->willReturn('product_model_2');
-        $productModel3->getCode()->willReturn('product_model_3');
+        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(4);
 
         $this->initialize();
         $this->read()->shouldReturn($productModel1);
         $this->read()->shouldReturn($product1);
         $this->read()->shouldReturn($productModel2);
         $this->read()->shouldReturn($product2);
-        $this->read()->shouldReturn($product3);
-        $this->read()->shouldReturn($productModel3);
         $this->read()->shouldReturn(null);
     }
 
-    function it_reads_products_and_product_models_with_read_children(
+    function it_reads_products_and_product_models_with_their_children(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository,
+        ProductQueryBuilderInterface $pqb,
         StepExecution $stepExecution,
         ChannelInterface $channel,
-        ProductQueryBuilderInterface $pqb,
+        JobParameters $jobParameters,
         CursorInterface $cursor,
-        ProductModelInterface $productModel1,
-        ProductModelInterface $productModel2,
-        ProductModelInterface $productModel3,
-        ProductInterface $product1,
-        ProductInterface $product2,
-        ProductInterface $product3,
-        JobParameters $jobParameters
     ) {
         $this->beConstructedWith(
             $pqbFactory,
             $channelRepository,
+            $productRepository,
+            $productModelRepository,
             true
         );
-
+        $jobParameters->get('filters')->willReturn(
+            [
+                'data' => [
+                    [
+                        'field' => 'id',
+                        'operator' => 'NOT IN',
+                        'value' => [1, 2, 3, 4, 42],
+                    ],
+                    [
+                        'field' => 'label_or_identifier',
+                        'operator' => 'CONTAINS',
+                        'value' => 'something',
+                    ],
+                ],
+                'structure' => [
+                    'scope' => 'mobile',
+                    'locales' => ['fr_FR', 'en_US'],
+                ],
+            ]
+        );
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
         $this->setStepExecution($stepExecution);
 
-        $filters = [
-            'data' => [
-                [
-                    'field' => 'id',
-                    'operator' => 'NOT IN',
-                    'value' => [1, 2, 3, 4, 42],
-                ],
-                [
-                    'field' => 'label_or_identifier',
-                    'operator' => 'CONTAINS',
-                    'value' => 'something',
-                ],
-            ],
-            'structure' => [
-                'scope' => 'mobile',
-                'locales' => ['fr_FR', 'en_US'],
-            ],
-        ];
-        $readChildrenFiltersData = [
-            [
-                'field' => 'self_and_ancestor.id',
-                'operator' => 'NOT IN',
-                'value' => [1, 2, 3, 4, 42],
-            ],
-            [
-                'field' => 'self_and_ancestor.label_or_identifier',
-                'operator' => 'CONTAINS',
-                'value' => 'something',
-            ],
-        ];
-
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('filters')->willReturn($filters);
-
-        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
         $channel->getCode()->willReturn('mobile');
+        $channelRepository->findOneByIdentifier('mobile')->willReturn($channel);
 
-        $pqbFactory->create(['filters' => $readChildrenFiltersData, 'default_scope' => 'mobile'])
-            ->shouldBeCalled()
-            ->willReturn($pqb);
-        $pqb->execute()
-            ->shouldBeCalled()
-            ->willReturn($cursor);
+        $pqbFactory->create(
+            [
+                'filters' => [
+                    [
+                        'field' => 'self_and_ancestor.id',
+                        'operator' => 'NOT IN',
+                        'value' => [1, 2, 3, 4, 42],
+                    ],
+                    [
+                        'field' => 'self_and_ancestor.label_or_identifier',
+                        'operator' => 'CONTAINS',
+                        'value' => 'something',
+                    ],
+                ],
+                'default_scope' => 'mobile',
+            ]
+        )->shouldBeCalled()->willReturn($pqb);
 
-        $products = [$productModel1, $product1, $productModel2, $product2, $product3, $productModel3];
-        $productsCount = count($products);
-        $cursor->valid()->will(
-            function () use (&$productsCount) {
-                return $productsCount-- > 0;
-            }
-        );
-        $cursor->current()->will(new ReturnPromise($products));
-        $cursor->next()->shouldBeCalledTimes(5);
-
-        $stepExecution->incrementSummaryInfo('read')->shouldBeCalledTimes(6);
-
-        $productModel1->getCode()->willReturn('product_model_1');
-        $productModel2->getCode()->willReturn('product_model_2');
-        $productModel3->getCode()->willReturn('product_model_3');
+        $pqb->execute()->shouldBeCalled()->willReturn($cursor);
+        $cursor->rewind()->shouldBeCalled();
 
         $this->initialize();
-        $this->read()->shouldReturn($productModel1);
-        $this->read()->shouldReturn($product1);
-        $this->read()->shouldReturn($productModel2);
-        $this->read()->shouldReturn($product2);
-        $this->read()->shouldReturn($product3);
-        $this->read()->shouldReturn($productModel3);
-        $this->read()->shouldReturn(null);
     }
 
     function it_returns_the_total_items_the_reader_is_going_to_read(
         ProductQueryBuilderFactoryInterface $pqbFactory,
         ChannelRepositoryInterface $channelRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository,
         StepExecution $stepExecution,
         ChannelInterface $channel,
         ProductQueryBuilderInterface $pqb,
@@ -230,10 +199,13 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         $this->beConstructedWith(
             $pqbFactory,
             $channelRepository,
+            $productRepository,
+            $productModelRepository,
             false
         );
-
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
         $this->setStepExecution($stepExecution);
+
         $filters = [
             'data' => [
                 [
@@ -261,28 +233,36 @@ class ProductAndProductModelReaderSpec extends ObjectBehavior
         $channel->getCode()->willReturn('mobile');
 
         $pqbFactory->create(['filters' => $filters['data'], 'default_scope' => 'mobile'])
-            ->shouldBeCalled()
-            ->willReturn($pqb);
+            ->shouldBeCalled()->willReturn($pqb);
         $pqb->execute()
             ->shouldBeCalled()
             ->willReturn($cursor);
 
-        $expectedTotalItems = 5;
-        $cursor->count()->willReturn($expectedTotalItems);
+        $cursor->rewind()->shouldBeCalled();
+        $cursor->count()->shouldBeCalled()->willReturn(5);
 
         $this->initialize();
-        $this->totalItems()->shouldReturn($expectedTotalItems);
+        $this->totalItems()->shouldReturn(5);
     }
 
     function it_throws_if_the_reader_is_not_initialized(
         ProductQueryBuilderFactoryInterface $pqbFactory,
-        ChannelRepositoryInterface $channelRepository
+        ChannelRepositoryInterface $channelRepository,
+        ProductRepositoryInterface $productRepository,
+        ProductModelRepositoryInterface $productModelRepository,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters
     ) {
         $this->beConstructedWith(
             $pqbFactory,
             $channelRepository,
+            $productRepository,
+            $productModelRepository,
             false
         );
+        $jobParameters->get('filters')->willReturn([]);
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $this->setStepExecution($stepExecution);
 
         $this->shouldThrow(\RuntimeException::class)
             ->during('totalItems');


### PR DESCRIPTION
Before this PR, there was an issue when trying to associate products via the mass associate action, for 2-way association types: when trying to associate a product/model to itself, a non-caught `Akeneo\Pim\Enrichment\Component\Product\Exception\TwoWayAssociationWithTheSameProductException` was thrown, and the job immediately failed, without skipping the wrong data.

Catching this exception and trying to skip the row would also result in an error (the infamous `A new entity was found through the relationship...`, because of the way the associations are designed (associated entities are fully hydrated when updating associations).

## Example:
Let's say you want to associate products B and C to products A, B and B

- 1st step:
    - the PQB hydrates the 3 products (see `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\AbstractCursor::getNextItemsFromIdentifiers()`
    - the reader passes product A to the processor
    - the processor updates product A's associations (B and C added). In the meantime products B and C's associations are also updated (product A is added), because of the 2-way associations, and product A is stored into the batch, waiting to be saved
- 2nd step: 
    - the reader passes product B to the processor
    - the processor produces an error (product B cannot be associated to itself)
    - here, either you clear doctrine cache, but then attempting to save product A will result in the ORM believing it's a new product, and there will be a duplicate key error in MySQL
    - or you somehow refresh product B so that its modifications are canceled, but then the association to product A won't be persisted

## Solution
This fix consists in:
- reducing the batch size of the mass associate action to 1, so that the affected entities are immediately  saved, and cache is cleared between each update attempt
- updating the ProductAndProductModelReader, so that it now uses a PQB returning IdentifierResults (readmodels) instead of Products/ProductModels => this allows the entities to be hydrated one by one instead of 100 by 100, so a failed update will not affect other hydrated products in the UOW

### Downsides
- this will slightly decrease the speed of mass actions, as now entities are fetched one by one, and especially the mass associate action, since entities will be saved 1 by one as well
- for 2-way associations, there will be a versioning entry for each product (e.g, if you want to associate product A to 10 other products, then it will produce 10 versioning entries for product A, because it will be saved 10 times)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
