### PR TITLE
PIM-11251: Fix option comparator when data is null

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,7 @@
 # 7.0.x
 
+- PIM-11251: Fix updated products count displayed in the process tracker without any change on the products
+
 # 7.0.34 (2023-10-17)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Comparator/Attribute/OptionComparator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Comparator/Attribute/OptionComparator.php
@@ -37,12 +37,16 @@ class OptionComparator implements ComparatorInterface
      */
     public function compare($data, $originals)
     {
+        $default = ['locale' => null, 'scope' => null, 'data' => null];
+        $originals = array_merge($default, $originals);
+
+        if (null === $data['data'] && null === $originals['data']) {
+            return null;
+        }
+
         if (!\is_string($data['data'])) {
             return $data;
         }
-
-        $default = ['locale' => null, 'scope' => null, 'data' => null];
-        $originals = \array_merge($default, $originals);
 
         if (\strtolower($data['data']) === \strtolower($originals['data'])) {
             return null;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Comparator/Attribute/OptionComparatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Comparator/Attribute/OptionComparatorSpec.php
@@ -53,6 +53,11 @@ class OptionComparatorSpec extends ObjectBehavior
         $originals = ['data' => '42', 'locale' => 'en_US', 'scope' => 'ecommerce'];
 
         $this->compare($changes, $originals)->shouldReturn(null);
+
+        $changes = ['data' => null, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+        $originals = ['data' => null, 'locale' => 'en_US', 'scope' => 'ecommerce'];
+
+        $this->compare($changes, $originals)->shouldReturn(null);
     }
 
     function it_compares_in_a_case_insensitive_way(): void


### PR DESCRIPTION
**Description**

In this PR we fixed an issue with the option comparator used to tell if a value is different when importing. When the value read was null the comparator automatically returned a difference even if the value was already null in the product