### PR TITLE
PIM-11269: Fix potential lost connection during 6.0 -> 7.0 migration

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11269: Fix potential lost connection during 6.0 -> 7.0 migration
+
 # 7.0.37 (2023-11-13)
 
 ## Bug fixes
@@ -13,6 +17,8 @@
 PIM-11266: Fix export value starting with "=<" causes error when opening in Excel
 
 # 7.0.35 (2023-10-27)
+
+## Bug fixes
 
 - PIM-11251: Fix updated products count displayed in the process tracker without any change on the products
 


### PR DESCRIPTION
During `doctrine:migration:migrate`, if the `pim:product:migrate-to-uuid` command lasts more than 8 hours (which can happen with big catalogs), MySQL will close the Doctrine migration's connection, causing the migration to fail. ("MySQL server has gone away...")
Also, some SQL queries (make product_id columns nullable) used to be executed even if they didn't need to (already done in a previous attempt).

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
