### PR TITLE
PIM-11266: Fix value starting with "=<" causes error when exporting in Excel

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+PIM-11266: Fix export value starting with "=<" causes error when opening in Excel
+
 # 7.0.35 (2023-10-27)
 
 - PIM-11251: Fix updated products count displayed in the process tracker without any change on the products


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, 

I replaced FormulaCell by StringCell: we didn't want that value in PIM are interpreted as formula when opening it in Excel, it also remove the possibility to made formula injection through the PIM (https://akeneo.atlassian.net/browse/PIM-10640)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
