### PR TITLE
PIM-11265: Fix mass delete action when using big grid filters

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11265: Fix mass delete action when using big grid filters
+
 # 7.0.36 (2023-11-10)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-delete-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-delete-action.js
@@ -54,11 +54,11 @@ define([
       let actionParameters = this.getActionParameters();
       actionParameters.actionName = this.route_parameters['actionName'];
       actionParameters.gridName = this.route_parameters['gridName'];
-      const query = `?${$.param(actionParameters)}`;
 
       return $.ajax({
-        url: Routing.generate('pim_enrich_mass_edit_rest_get_filter') + query,
+        url: Routing.generate('pim_enrich_mass_edit_rest_get_filter'),
         method: 'POST',
+        data: actionParameters,
       }).then(response => {
         return {
           filters: response.filters,


### PR DESCRIPTION
Too big grid filters (e.g: in list with a lot of entries) used to cause 414 errors because they were sent as a query string

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
