### PR TITLE
PIM-10903: Fix Doctrine warning related to Product and Group

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-10903: Fix Doctrine warning related to Product and Group
+
 # 7.0.38 (2023-11-16)
 
 ## Bug fixes
@@ -16,7 +20,7 @@
 
 ## Bug fixes
 
-PIM-11266: Fix export value starting with "=<" causes error when opening in Excel
+- PIM-11266: Fix export value starting with "=<" causes error when opening in Excel
 
 # 7.0.35 (2023-10-27)
 
@@ -34,11 +38,15 @@ PIM-11266: Fix export value starting with "=<" causes error when opening in Exce
 
 # 7.0.32 (2023-09-27)
 
+## Bug fixes
+
 - PIM-11200: Fix versioning on table attribute in case of column reordering
 
 # 7.0.31 (2023-09-25)
 
 # 7.0.30 (2023-09-25)
+
+## Bug fixes
 
 - PIM-11196: Fix DQI migration script Version_7_0_20220214101647
 
@@ -101,6 +109,8 @@ PIM-11266: Fix export value starting with "=<" causes error when opening in Exce
 # 7.0.11 (2023-03-21)
 
 # 7.0.10 (2023-02-28)
+
+## Bug fixes
 
 - RAB-1356: [Backport PIM-10840]: Fix attribute update date on attribute options change above 10000 options
 - RAB-1356: [Backport PIM-10853]: Fix type checking in SaveFamilyVariantOnFamilyUpdate bulk action

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
@@ -54,7 +54,6 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
     manyToMany:
         groups:
             targetEntity: Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface
-            inversedBy: products
             joinTable:
                 name: pim_catalog_group_product
                 joinColumns:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/Group.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/Group.php
@@ -27,9 +27,6 @@ class Group implements GroupInterface
     /** @var GroupTypeInterface */
     protected $type;
 
-    /**  @var ArrayCollection */
-    protected $products;
-
     /**
      * Used locale to override Translation listener's locale
      * this is not a mapped field of entity metadata, just a simple property
@@ -46,7 +43,6 @@ class Group implements GroupInterface
      */
     public function __construct()
     {
-        $this->products = new ArrayCollection();
         $this->translations = new ArrayCollection();
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This issue appeared following [PIM-10149](https://github.com/akeneo/pim-community-dev/pull/15725).  This mapping has been removed to avoid using it because it can leads to OOM. We decided to fix this warning by removing the inversedBy clause in the Product.orm.yml because we don’t use it anymore.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc


[PIM-10149]: https://akeneo.atlassian.net/browse/PIM-10149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ