### PR TITLE
PIM-10985: Mark skipped migrations as executed

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+- PIM-10985: Mark skipped migrations as executed
+
 # 6.0.109 (2023-11-08)
 
 # 6.0.108 (2023-11-06)

--- a/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_connections.php
+++ b/upgrades/schema/Version_4_0_20191031124707_update_from_clients_to_connections.php
@@ -48,7 +48,12 @@ SQL;
         $clientsStatement = $this->dbalConnection()->executeQuery($selectClients);
         $clients = $clientsStatement->fetchAllAssociative();
 
-        $this->skipIf(empty($clients), 'No API connection to migrate.');
+        if (empty($clients)) {
+            $this->write('No API connection to migrate.');
+
+            return;
+        }
+
         $this->write(sprintf('%s API connections found. They will be migrate to Connection.', count($clients)));
 
         $clients = $this->generateConnectionsCode($clients);

--- a/upgrades/schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts.php
+++ b/upgrades/schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts.php
@@ -10,10 +10,12 @@ final class Version_5_0_20220201155016_add_user_account_locking_after_too_many_a
     public function up(Schema $schema) : void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-        $this->skipIf(
-            $this->hasColumn($schema, 'consecutive_authentication_failure_counter') && $this->hasColumn($schema, 'authentication_failure_reset_date'),
-            'consecutive_authentication_failure_counter & authentication_failure_reset_date column already exists in oro_user'
-        );
+        if ($this->hasColumn($schema, 'consecutive_authentication_failure_counter') &&
+            $this->hasColumn($schema, 'authentication_failure_reset_date')) {
+            $this->write('consecutive_authentication_failure_counter & authentication_failure_reset_date column already exists in oro_user');
+
+            return;
+        }
 
         $this->addSql('alter table oro_user add consecutive_authentication_failure_counter int default 0');
         $this->addSql('alter table oro_user add authentication_failure_reset_date datetime  default null');

--- a/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
+++ b/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
@@ -11,10 +11,11 @@ final class Version_5_0_20220801160000_modify_metric_family_and_default_metric_u
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $this->columnsAreModified($schema),
-            'metric_family and default_metric_unit columns are already modified'
-        );
+        if ($this->columnsAreModified($schema)) {
+            $this->write('metric_family and default_metric_unit columns are already modified');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE pim_catalog_attribute MODIFY COLUMN metric_family VARCHAR(100), MODIFY COLUMN default_metric_unit VARCHAR(100)');
     }

--- a/upgrades/schema/Version_6_0_20210331105730_remove_datagrid_view_unique_label_constraint.php
+++ b/upgrades/schema/Version_6_0_20210331105730_remove_datagrid_view_unique_label_constraint.php
@@ -34,7 +34,12 @@ final class Version_6_0_20210331105730_remove_datagrid_view_unique_label_constra
         SQL;
         $uniqueConstraintKeyName = $this->dbalConnection()->executeQuery($selectUniqueConstraint)->fetchOne();
 
-        $this->skipIf(!$uniqueConstraintKeyName, 'pim_datagrid_view unique constraint is already up to date');
+        if (!$uniqueConstraintKeyName) {
+            $this->write('pim_datagrid_view unique constraint is already up to date');
+
+            return;
+        }
+
         $this->addSql("ALTER TABLE pim_datagrid_view DROP index $uniqueConstraintKeyName");
     }
 

--- a/upgrades/schema/Version_6_0_20210427163307_add_user_account_locking_after_too_many_attempts.php
+++ b/upgrades/schema/Version_6_0_20210427163307_add_user_account_locking_after_too_many_attempts.php
@@ -14,10 +14,11 @@ final class Version_6_0_20210427163307_add_user_account_locking_after_too_many_a
     public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
-        $this->skipIf(
-            $this->hasColumn($schema, 'consecutive_authentication_failure_counter') && $this->hasColumn($schema, 'authentication_failure_reset_date'),
-            'consecutive_authentication_failure_counter & authentication_failure_reset_date column already exists in oro_user'
-        );
+        if ($this->hasColumn($schema, 'consecutive_authentication_failure_counter') && $this->hasColumn($schema, 'authentication_failure_reset_date')) {
+            $this->write('consecutive_authentication_failure_counter & authentication_failure_reset_date column already exists in oro_user');
+
+            return;
+        }
 
         $this->addSql('alter table oro_user add consecutive_authentication_failure_counter int default 0');
         $this->addSql('alter table oro_user add authentication_failure_reset_date datetime  default null ');

--- a/upgrades/schema/Version_6_0_20211119154203_add_is_stoppable_in_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211119154203_add_is_stoppable_in_job_execution.php
@@ -137,10 +137,11 @@ final class Version_6_0_20211119154203_add_is_stoppable_in_job_execution extends
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $schema->getTable('akeneo_batch_job_execution')->hasColumn('is_stoppable'),
-            'is_stoppable column already exists in akeneo_batch_job_execution'
-        );
+        if ($schema->getTable('akeneo_batch_job_execution')->hasColumn('is_stoppable')) {
+            $this->write('is_stoppable column already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql("ALTER TABLE akeneo_batch_job_execution ADD is_stoppable TINYINT(1) DEFAULT 0");
         $this->addSql("UPDATE akeneo_batch_job_execution SET is_stoppable = 1 WHERE job_instance_id IN (SELECT id FROM akeneo_batch_job_instance WHERE code IN ('"

--- a/upgrades/schema/Version_6_0_20211122154203_add_step_count_in_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211122154203_add_step_count_in_job_execution.php
@@ -194,10 +194,11 @@ final class Version_6_0_20211122154203_add_step_count_in_job_execution extends A
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $schema->getTable('akeneo_batch_job_execution')->hasColumn('step_count'),
-            'step_count column already exists in akeneo_batch_job_execution'
-        );
+        if ($schema->getTable('akeneo_batch_job_execution')->hasColumn('step_count')) {
+            $this->write('step_count column already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE akeneo_batch_job_execution ADD step_count INT DEFAULT 1');
 

--- a/upgrades/schema/Version_6_0_20211124154203_add_is_visible_in_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211124154203_add_is_visible_in_job_execution.php
@@ -24,10 +24,11 @@ final class Version_6_0_20211124154203_add_is_visible_in_job_execution extends A
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $schema->getTable('akeneo_batch_job_execution')->hasColumn('is_visible'),
-            'is_visible column already exists in akeneo_batch_job_execution'
-        );
+        if ($schema->getTable('akeneo_batch_job_execution')->hasColumn('is_visible')) {
+            $this->write('is_visible column already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql("ALTER TABLE akeneo_batch_job_execution ADD is_visible TINYINT(1) DEFAULT 1");
         $this->addSql("UPDATE akeneo_batch_job_execution SET is_visible = 0 WHERE job_instance_id IN (SELECT id FROM akeneo_batch_job_instance WHERE code IN ('"

--- a/upgrades/schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution.php
@@ -9,7 +9,11 @@ final class Version_6_0_20211124163100_add_index_to_improve_search_on_job_execut
 {
     public function up(Schema $schema) : void
     {
-        $this->skipIf($this->indexesExists(), 'Indexed IDX_STARTED_TIME, IDX_USER and IDX_STATUS already exists in akeneo_batch_job_execution');
+        if ($this->indexesExists()) {
+            $this->write('Indexed IDX_STARTED_TIME, IDX_USER and IDX_STATUS already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX user_idx ON akeneo_batch_job_execution (user)');
         $this->addSql('CREATE INDEX status_idx ON akeneo_batch_job_execution (status)');

--- a/upgrades/schema/Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution.php
@@ -9,7 +9,11 @@ final class Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution 
 {
     public function up(Schema $schema) : void
     {
-        $this->skipIf($this->indexExists(), 'Indexed is_visible_idx already exists in akeneo_batch_job_execution');
+        if ($this->indexExists()) {
+            $this->write('Indexed is_visible_idx already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX is_visible_idx ON akeneo_batch_job_execution (is_visible)');
     }

--- a/upgrades/schema/Version_6_0_20211130113100_add_index_to_improve_search_on_job_instance.php
+++ b/upgrades/schema/Version_6_0_20211130113100_add_index_to_improve_search_on_job_instance.php
@@ -11,7 +11,11 @@ final class Version_6_0_20211130113100_add_index_to_improve_search_on_job_instan
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->indexExists(), 'Index code_idx already exists in akeneo_batch_job_instance');
+        if ($this->indexExists()) {
+            $this->write('Index code_idx already exists in akeneo_batch_job_instance');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX code_idx ON akeneo_batch_job_instance (code)');
     }

--- a/upgrades/schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution.php
+++ b/upgrades/schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution.php
@@ -11,7 +11,7 @@ final class Version_6_0_20211207154203_add_is_trackable_in_step_execution extend
 {
     public function up(Schema $schema): void
     {
-        if ($this->$schema->getTable('akeneo_batch_step_execution')->hasColumn('is_trackable')) {
+        if ($schema->getTable('akeneo_batch_step_execution')->hasColumn('is_trackable')) {
             $this->write('is_trackable column already exists in akeneo_batch_step_execution');
 
             return;

--- a/upgrades/schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution.php
+++ b/upgrades/schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution.php
@@ -11,10 +11,11 @@ final class Version_6_0_20211207154203_add_is_trackable_in_step_execution extend
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $schema->getTable('akeneo_batch_step_execution')->hasColumn('is_trackable'),
-            'is_trackable column already exists in akeneo_batch_step_execution'
-        );
+        if ($this->$schema->getTable('akeneo_batch_step_execution')->hasColumn('is_trackable')) {
+            $this->write('is_trackable column already exists in akeneo_batch_step_execution');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE akeneo_batch_step_execution ADD is_trackable TINYINT(1) DEFAULT 0');
     }

--- a/upgrades/schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query.php
+++ b/upgrades/schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query.php
@@ -11,7 +11,11 @@ final class Version_6_0_20211213191300_add_index_to_improve_process_tracker_coun
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->indexExists(), 'Index job_instance_id_user_status_is_visible_idx already exists in akeneo_batch_job_instance');
+        if ($this->indexExists()) {
+            $this->write('Index job_instance_id_user_status_is_visible_idx already exists in akeneo_batch_job_instance');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX job_instance_id_user_status_is_visible_idx ON akeneo_batch_job_execution (job_instance_id, user, status, is_visible)');
     }

--- a/upgrades/schema/Version_6_0_20211221170000_modify_metric_family_and_default_metric_unit.php
+++ b/upgrades/schema/Version_6_0_20211221170000_modify_metric_family_and_default_metric_unit.php
@@ -11,10 +11,11 @@ final class Version_6_0_20211221170000_modify_metric_family_and_default_metric_u
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $this->columnsAreModified($schema),
-            'metric_family and default_metric_unit columns are already modified'
-        );
+        if ($this->columnsAreModified($schema)) {
+            $this->write('metric_family and default_metric_unit columns are already modified');
+
+            return;
+        }
 
         $this->addSql('ALTER TABLE pim_catalog_attribute MODIFY COLUMN metric_family VARCHAR(100), MODIFY COLUMN default_metric_unit VARCHAR(100)');
     }

--- a/upgrades/schema/Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_queue.php
+++ b/upgrades/schema/Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_queue.php
@@ -11,7 +11,12 @@ final class Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_que
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->tableDoesNotExist(), 'The table akeneo_batch_job_execution_queue does not exist');
+        if ($this->tableDoesNotExist()) {
+            $this->write('The table akeneo_batch_job_execution_queue does not exist');
+
+            return;
+        }
+
         if (!$this->queueJobIsEmpty()) {
             throw new \RuntimeException('Some jobs need have not be launched, please launch `bin/console akeneo:batch:migrate-job-messages-from-old-queue` to migrate them or execute `TRUNCATE akeneo_batch_job_execution_queue` if you didn\'t want to migrate them');
         }

--- a/upgrades/schema/Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_execution_tables.php
+++ b/upgrades/schema/Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_execution_tables.php
@@ -21,8 +21,17 @@ final class Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_exec
 
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->isSassVersion(), 'This migration is only for non Sass version');
-        $this->skipIf($this->isMigrationDone(), 'Migration already done');
+        if ($this->isSassVersion()) {
+            $this->write('This migration is only for non Sass version');
+
+            return;
+        }
+
+        if ($this->isMigrationDone()) {
+            $this->write('Migration already done');
+
+            return;
+        }
 
         $this->addSql("UPDATE akeneo_batch_job_execution SET is_stoppable = 0 WHERE is_stoppable IS NULL");
         $this->addSql("UPDATE akeneo_batch_job_execution SET step_count = 1 WHERE step_count IS NULL");

--- a/upgrades/schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution.php
+++ b/upgrades/schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution.php
@@ -11,7 +11,11 @@ final class Version_6_0_20220520114800_add_start_time_index_on_job_execution ext
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->indexExists(), 'Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
+        if ($this->indexExists()) {
+            $this->write('Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX start_time_idx ON akeneo_batch_job_execution (start_time)');
     }

--- a/upgrades/schema/Version_6_0_20220524122443_oro_user_field_consecutive_authentication_failure_counter_is_not_nullable.php
+++ b/upgrades/schema/Version_6_0_20220524122443_oro_user_field_consecutive_authentication_failure_counter_is_not_nullable.php
@@ -16,10 +16,11 @@ final class Version_6_0_20220524122443_oro_user_field_consecutive_authentication
 
     public function up(Schema $schema): void
     {
-        $this->skipIf(
-            $this->isMigrationAlreadyApplied($schema),
-            'Column oro_user.consecutive_authentication_failure_counter is already INT UNSIGNED NOT NULL DEFAULT 0'
-        );
+        if ($this->isMigrationAlreadyApplied($schema)) {
+            $this->write('Column oro_user.consecutive_authentication_failure_counter is already INT UNSIGNED NOT NULL DEFAULT 0');
+
+            return;
+        }
 
         // should not be any null in this column, but have to be 100% sure
         $this->addSql(<<<SQL

--- a/upgrades/schema/Version_6_0_20220524145600_add_updated_index_on_category.php
+++ b/upgrades/schema/Version_6_0_20220524145600_add_updated_index_on_category.php
@@ -15,7 +15,11 @@ final class Version_6_0_20220524145600_add_updated_index_on_category extends Abs
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->indexExists(), 'Indexed updated_idx already exists in pim_catalog_category');
+        if ($this->indexExists()) {
+            $this->write('Indexed updated_idx already exists in pim_catalog_category');
+
+            return;
+        }
 
         $this->addSql('CREATE INDEX updated_idx ON pim_catalog_category (updated)');
     }

--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -19,13 +19,62 @@ trait ExecuteMigrationTrait
      */
     abstract protected function getParameter(string $parameter);
 
-    private function reExecuteMigration(string $migrationLabel): void
+    /**
+     * TODO on Master rebase:
+     * This method should be renamed to "executeMigration", and the second parameter should be renamed to "reExecute".
+     */
+    private function reExecuteMigration(string $migrationLabel, bool $removePreviouslyExecutedMigration = false): void
     {
         $pathFinder = new PhpExecutableFinder();
         $phpCommand = $pathFinder->find();
 
         $rootDir = $this->getParameter('kernel.project_dir');
 
+        if ($removePreviouslyExecutedMigration) {
+            $this->checkMigrationIsIrreversible($phpCommand, $rootDir, $migrationLabel);
+            $this->deleteMigration($phpCommand, $rootDir, $migrationLabel);
+        }
+        $this->innerExecuteMigration($phpCommand, $rootDir, $migrationLabel);
+    }
+
+    private function innerExecuteMigration(string $phpCommand, string $rootDir, string $migrationLabel): void
+    {
+        $output = [];
+        $status = null;
+
+        exec(
+            sprintf(
+                "%s %s/bin/console doctrine:migrations:execute 'Pim\Upgrade\Schema\Version%s' --up -n",
+                $phpCommand,
+                $rootDir,
+                $migrationLabel
+            ),
+            $output,
+            $status
+        );
+        Assert::assertEquals(0, $status, \json_encode($output));
+    }
+
+    private function deleteMigration(string $phpCommand, string $rootDir, string $migrationLabel): void
+    {
+        $output = [];
+        $status = null;
+
+        exec(
+            sprintf(
+                "%s %s/bin/console doctrine:migrations:version 'Pim\Upgrade\Schema\Version%s' --delete -n",
+                $phpCommand,
+                $rootDir,
+                $migrationLabel
+            ),
+            $output,
+            $status
+        );
+        Assert::assertEquals(0, $status, 'Migration were not executed.');
+    }
+
+    private function checkMigrationIsIrreversible(string $phpCommand, string $rootDir, string $migrationLabel): void
+    {
         $output = [];
         $status = null;
 
@@ -41,17 +90,5 @@ trait ExecuteMigrationTrait
         );
 
         Assert::assertEquals(1, $status, 'Migration should be irreversible.');
-
-        exec(
-            sprintf(
-                "%s %s/bin/console doctrine:migrations:execute 'Pim\Upgrade\Schema\Version%s' --up -n",
-                $phpCommand,
-                $rootDir,
-                $migrationLabel
-            ),
-            $output,
-            $status
-        );
-        Assert::assertEquals(0, $status, \json_encode($output));
     }
 }

--- a/upgrades/test_schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts_Integration.php
@@ -43,7 +43,7 @@ final class Version_5_0_20220201155016_add_user_account_locking_after_too_many_a
         Assert::assertEquals(false, $this->columnExists());
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertEquals(true, $this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20210427163307_add_user_account_locking_after_too_many_attempts_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210427163307_add_user_account_locking_after_too_many_attempts_Integration.php
@@ -43,7 +43,7 @@ final class Version_6_0_20210427163307_add_user_account_locking_after_too_many_a
         Assert::assertEquals(false, $this->columnExists());
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertEquals(true, $this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211119154203_add_is_stoppable_in_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211119154203_add_is_stoppable_in_job_execution_Integration.php
@@ -62,7 +62,7 @@ class Version_6_0_20211119154203_add_is_stoppable_in_job_execution_Integration e
         $this->createJobExecution($jobInstanceId);
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211122154203_add_step_count_in_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211122154203_add_step_count_in_job_execution_Integration.php
@@ -64,7 +64,7 @@ class Version_6_0_20211122154203_add_step_count_in_job_execution_Integration ext
         $this->createJobExecution($jobInstanceId);
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211124154203_add_is_visible_in_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211124154203_add_is_visible_in_job_execution_Integration.php
@@ -62,7 +62,7 @@ class Version_6_0_20211124154203_add_is_visible_in_job_execution_Integration ext
         $this->createJobExecution($jobInstanceId);
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_In
         $this->dropIndexesIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexesExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20211129163800_add_index_on_is_visible_in_job_execution_Integr
         $this->dropIndexIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211130113100_add_index_to_improve_search_on_job_instance_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211130113100_add_index_to_improve_search_on_job_instance_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20211130113100_add_index_to_improve_search_on_job_instance_Int
         $this->dropIndexIfExists('code_idx');
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexExists('code_idx'));
     }

--- a/upgrades/test_schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211207154203_add_is_trackable_in_step_execution_Integration.php
@@ -46,7 +46,7 @@ class Version_6_0_20211207154203_add_is_trackable_in_step_execution_Integration 
         $this->dropColumnIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->columnExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_quer
         $this->dropIndexIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexExists());
     }

--- a/upgrades/test_schema/Version_6_0_20211221170000_modify_metric_family_and_default_metric_unit_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211221170000_modify_metric_family_and_default_metric_unit_Integration.php
@@ -42,7 +42,7 @@ class Version_6_0_20211221170000_modify_metric_family_and_default_metric_unit_In
         $attributeId = $this->addAttribute($metricFamily, $defaultMetricUnit);
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeId, $metricFamily, $defaultMetricUnit));
     }

--- a/upgrades/test_schema/Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_queue_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_queue_Integration.php
@@ -48,7 +48,7 @@ class Version_6_0_20220518130906_drop_table_akeneo_batch_job_execution_queue_Int
         $this->createJobQueueTable();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertFalse($this->jobQueueTableExists());
     }

--- a/upgrades/test_schema/Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_execution_tables_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_execution_tables_Integration.php
@@ -72,7 +72,7 @@ class Version_6_0_20220518134914_set_not_null_fields_for_job_and_step_execution_
 
         $this->insertJobExecutionWithNullValues();
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         $this->assertFalse($this->columnIsNullable('akeneo_batch_job_execution', 'step_count'));
         $this->assertFalse($this->columnIsNullable('akeneo_batch_job_execution', 'is_stoppable'));

--- a/upgrades/test_schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integrati
         $this->dropIndexIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexExists());
     }

--- a/upgrades/test_schema/Version_6_0_20220524145600_add_updated_index_on_category_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220524145600_add_updated_index_on_category_Integration.php
@@ -45,7 +45,7 @@ class Version_6_0_20220524145600_add_updated_index_on_category_Integration exten
         $this->dropIndexIfExists();
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL, true);
 
         Assert::assertTrue($this->indexExists());
     }


### PR DESCRIPTION
# The issue

When coding migrations, we usually used "skipIf" method in case of "the state of the PIM is already migrated". This method skips the migration, that's OK, but it did not add it as "executed". Each time we will try to re-execute migrations, we will try to re-execute theses ones.
This is not a good practice ! "skipIf" means "skip and retry later".

# The solution

Don't use "skipIf" ! Return is OK, it will mark migration as executed.