### PR TITLE
PIM-11289: Fix case-sensitive check in UniqueAxesCombinationSet

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11289: Fix case-sensitive check in UniqueAxesCombinationSet
+
 # 7.0.39 (2023-11-21)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueAxesCombinationSet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueAxesCombinationSet.php
@@ -55,7 +55,7 @@ class UniqueAxesCombinationSet
 
         if (isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination])) {
             $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination];
-            if ($cachedIdentifier !== $entity->getIdentifier()) {
+            if ($cachedIdentifier !== \mb_strtolower($entity->getIdentifier())) {
                 if ($entity instanceof ProductInterface) {
                     throw new AlreadyExistingAxisValueCombinationException(
                         $cachedIdentifier,

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
@@ -55,10 +55,17 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
         $variantProductB->setFamilyVariant($familyVariant);
         $variantProductB->setParent($productModel);
 
+        $variantProductBBis = new Product();
+        $variantProductBBis->addValue($identifierB);
+        $variantProductBBis->setIdentifier('PRODUCT_B');
+        $variantProductBBis->setFamilyVariant($familyVariant);
+        $variantProductBBis->setParent($productModel);
+
         $this->addCombination($productModel, '[a_color]');
         $this->addCombination($anotherProductModel, '[another_color]');
         $this->addCombination($variantProductA, '[a_size]');
         $this->addCombination($variantProductB, '[another_size]');
+        $this->addCombination($variantProductBBis, '[another_size]');
     }
 
     function it_does_not_add_same_combination_of_axis_values_twice_for_product_models()


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

There is a case sensitivity issue when we try to compare a variant product with an uppercased identifier because we store cached identifier into lowercase and we do the check without lowercasing variant identifier.

Note for the pull-up into master: Don't pull-up those changes as this class has been already reworked and fixed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
