### PR TITLE
Fix type for Dropdown.Surtitle

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Dropdown/Surtitle/Surtitle.tsx
+++ b/front-packages/akeneo-design-system/src/components/Dropdown/Surtitle/Surtitle.tsx
@@ -19,7 +19,7 @@ const Title = styled.span`
   text-overflow: ellipsis;
 `;
 
-type SurtitleProps = {label: string};
+type SurtitleProps = {label: string; children?: React.ReactNode};
 
 const Surtitle: React.FC<SurtitleProps> = ({label, children, ...rest}) => (
   <SurtitleContainer {...rest}>


### PR DESCRIPTION
(first contrib, tell me if I'm missing anything)
**Description**

When using the Dropdown.Surtitle element from the DSM I ran into an error when using the examples provided. The component didn't allow children because it is not in the props.

When testing locally, my quick&dirty fix was to modify the node_modules type directly
![image](https://github.com/akeneo/pim-community-dev/assets/56344911/9f471202-2017-4bb8-be76-be453e26da2c)

It worked well so I'm now adding the fix here.

**More info**
The example I tried to use: https://dsm.akeneo.com/?path=/docs/components-dropdown--surtitle-item#surtitle-item
The error:
![Screenshot 2023-12-29 at 12 12 08](https://github.com/akeneo/pim-community-dev/assets/56344911/dc7049f6-c990-44f1-94c9-d76bddceee32)

**Definition Of Done**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
