### PR TITLE
PIM-11342: Fix infinite loop in Re-compute DQI products scores

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11342: Fix infinite loop in Re-compute DQI products scores
+
 # 7.0.46 (2024-01-04)
 
 # 7.0.45 (2023-12-28)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/RecomputeProductScoresTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/RecomputeProductScoresTasklet.php
@@ -71,13 +71,22 @@ final class RecomputeProductScoresTasklet implements TaskletInterface
         $query = <<<SQL
             SELECT BIN_TO_UUID(uuid) as uuid 
             FROM pim_catalog_product 
-            WHERE uuid > :lastUuid ORDER BY uuid ASC LIMIT :limit
         SQL;
+
+        $parameters = ['limit' => self::BULK_SIZE];
+        $parametersTypes = ['limit' => \PDO::PARAM_INT];
+
+        if ('' !== $lastProductUuid) {
+            $query .= ' WHERE uuid > UUID_TO_BIN(:lastUuid)';
+            $parameters['lastUuid'] = $lastProductUuid;
+        }
+
+        $query .= ' ORDER BY uuid ASC LIMIT :limit';
 
         return $this->connection->executeQuery(
             $query,
-            ['lastUuid' => $lastProductUuid, 'limit' => self::BULK_SIZE],
-            ['lastUuid' => \PDO::PARAM_STR, 'limit' => \PDO::PARAM_INT]
+            $parameters,
+            $parametersTypes,
         )->fetchFirstColumn();
     }
 


### PR DESCRIPTION
There were a infinite loop in the job that re-compute the score of all the products. In the SQL query, the condition on the UUID was comparing an UUID as string with an UUID as binary.

The script is not tested, and it would need too much effort for a SLA. Especially as this job is only executed manually, and should be fully reworked.