### PR TITLE
chore: update lcobucci/jwt version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,7 @@
         "guzzlehttp/guzzle": "^7.5.0",
         "imagine/imagine": "1.3.3",
         "khaled.alshamaa/ar-php": "^6.2",
-        "lcobucci/jwt": "^4.2",
+        "lcobucci/jwt": ">=4.2.0 <4.3.0",
         "league/flysystem": "^3.11.0",
         "liip/imagine-bundle": "2.10.0",
         "maennchen/zipstream-php": "^2.4.0",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Adjust the version constraint for lcobucci/jwt to ">=4.2.0 <4.3.0" in the composer.json file. This ensures that we include any version from the 4.2.X range while explicitly excluding version 4.3.0. This change is made to maintain compatibility, because as of 4.3.0 lcobucci/jwt requires "lcobucci/clock": "^2.0 || ^3.0", so lcobucci/clock > 3 is installed, which in turn requires "php": "~8.2.0 || ~8.3.0". However, Akeneo requires 8.1