### PR TITLE
[backport PIM-11406] PIM-11418: Fix API Product Model endpoint when trying to update family with wrong case

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11418: Fix API Product Model endpoint when trying to update family with wrong case
+
 # 7.0.58 (2024-03-18)
 
 ## Bug fixes

--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -2,7 +2,7 @@
 
 ## Bug fixes
 
-- PIM-11418: Fix API Product Model endpoint when trying to update family with wrong case
+- [Backport PIM-11406] PIM-11418: Fix case sensitivity family and family variant on product model update and product update
 
 # 7.0.58 (2024-03-18)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ExternalApi/ProductModelUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ExternalApi/ProductModelUpdater.php
@@ -81,7 +81,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
     private function validateFamilyCode($familyCode, ProductModelInterface $productModel): void
     {
         if (null !== $productModel->getId()) {
-            if (!is_string($familyCode) || empty($familyCode) || $productModel->getFamily()->getCode() !== $familyCode) {
+            if (!is_string($familyCode) || empty($familyCode) || \strtolower($productModel->getFamily()->getCode()) !== \strtolower($familyCode)) {
                 throw ImmutablePropertyException::immutableProperty(
                     'family',
                     is_scalar($familyCode) ? $familyCode : gettype($familyCode),
@@ -98,7 +98,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
             throw InvalidPropertyTypeException::stringExpected('family', ProductModelInterface::class, $familyCode);
         }
 
-        if (null !== $productModel->getFamilyVariant() && $familyCode !== $productModel->getFamily()->getCode()) {
+        if (null !== $productModel->getFamilyVariant() && \strtolower($familyCode) !== \strtolower($productModel->getFamily()->getCode())) {
             throw InvalidPropertyException::expected(
                 sprintf(
                     'The family "%s" does not match the family of the variant "%s".',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ExternalApi/ProductModelUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ExternalApi/ProductModelUpdater.php
@@ -20,15 +20,9 @@ use Doctrine\Common\Util\ClassUtils;
  */
 class ProductModelUpdater implements ObjectUpdaterInterface
 {
-    /** @var ObjectUpdaterInterface */
-    private $productModelUpdater;
-
-    /**
-     * @param ObjectUpdaterInterface $productModelUpdater
-     */
-    public function __construct(ObjectUpdaterInterface $productModelUpdater)
-    {
-        $this->productModelUpdater = $productModelUpdater;
+    public function __construct(
+        private readonly ObjectUpdaterInterface $productModelUpdater
+    ) {
     }
 
     /**
@@ -81,7 +75,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
     private function validateFamilyCode($familyCode, ProductModelInterface $productModel): void
     {
         if (null !== $productModel->getId()) {
-            if (!is_string($familyCode) || empty($familyCode) || \strtolower($productModel->getFamily()->getCode()) !== \strtolower($familyCode)) {
+            if (!\is_string($familyCode) || empty($familyCode) || \strtolower($productModel->getFamily()->getCode()) !== \strtolower($familyCode)) {
                 throw ImmutablePropertyException::immutableProperty(
                     'family',
                     is_scalar($familyCode) ? $familyCode : gettype($familyCode),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductModelUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductModelUpdater.php
@@ -25,58 +25,19 @@ use Doctrine\Common\Util\ClassUtils;
  */
 class ProductModelUpdater implements ObjectUpdaterInterface
 {
-    /** @var PropertySetterInterface */
-    private $propertySetter;
-
-    /** @var ObjectUpdaterInterface */
-    private $valuesUpdater;
-
-    /** @var array */
-    private $ignoredFields;
-
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $familyVariantRepository;
-
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $productModelRepository;
-
-    /** @var ParentAssociationsFilter */
-    private $parentAssociationsFilter;
-
-    /** @var QuantifiedAssociationsFromAncestorsFilter */
-    private $quantifiedAssociationsFromAncestorsFilter;
-
-    /** @var QuantifiedAssociationsStructureValidatorInterface */
-    private $quantifiedAssociationsStructureValidator;
-
     /**
-     * @param PropertySetterInterface $propertySetter
-     * @param ObjectUpdaterInterface $valuesUpdater
-     * @param IdentifiableObjectRepositoryInterface $familyVariantRepository
-     * @param IdentifiableObjectRepositoryInterface $productModelRepository
-     * @param ParentAssociationsFilter $parentAssociationsFilter
-     * @param QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter
-     * @param QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator
-     * @param array $ignoredFields
+     * @param string[] $ignoredFields
      */
     public function __construct(
-        PropertySetterInterface $propertySetter,
-        ObjectUpdaterInterface $valuesUpdater,
-        IdentifiableObjectRepositoryInterface $familyVariantRepository,
-        IdentifiableObjectRepositoryInterface $productModelRepository,
-        ParentAssociationsFilter $parentAssociationsFilter,
-        QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
-        QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator,
-        array $ignoredFields
+        private readonly PropertySetterInterface $propertySetter,
+        private readonly ObjectUpdaterInterface $valuesUpdater,
+        private readonly IdentifiableObjectRepositoryInterface $familyVariantRepository,
+        private readonly IdentifiableObjectRepositoryInterface $productModelRepository,
+        private readonly ParentAssociationsFilter $parentAssociationsFilter,
+        private readonly QuantifiedAssociationsFromAncestorsFilter $quantifiedAssociationsFromAncestorsFilter,
+        private readonly QuantifiedAssociationsStructureValidatorInterface $quantifiedAssociationsStructureValidator,
+        private readonly array $ignoredFields
     ) {
-        $this->propertySetter = $propertySetter;
-        $this->valuesUpdater = $valuesUpdater;
-        $this->familyVariantRepository = $familyVariantRepository;
-        $this->productModelRepository = $productModelRepository;
-        $this->ignoredFields = $ignoredFields;
-        $this->parentAssociationsFilter = $parentAssociationsFilter;
-        $this->quantifiedAssociationsFromAncestorsFilter = $quantifiedAssociationsFromAncestorsFilter;
-        $this->quantifiedAssociationsStructureValidator = $quantifiedAssociationsStructureValidator;
     }
 
     /**
@@ -313,7 +274,7 @@ class ProductModelUpdater implements ObjectUpdaterInterface
         }
 
         $parent = $productModel->getParent();
-        if (null !== $parent && $familyVariantCode !== $parent->getFamilyVariant()->getCode()) {
+        if (null !== $parent && \strtolower($familyVariantCode) !== \strtolower($parent->getFamilyVariant()->getCode())) {
             throw InvalidPropertyException::expected(
                 sprintf(
                     'The parent is not a product model of the family variant "%s" but belongs to the family "%s".',

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -5,10 +5,9 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
-use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
+use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use PHPUnit\Framework\Assert;
-use Psr\Log\Test\TestLogger;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateListProductModelEndToEnd extends AbstractProductModelTestCase
@@ -337,6 +336,25 @@ JSON;
         $response = $result['http_response'];
 
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function testUpdateProductModelWithFamilyAndFamilyVariantIgnoringCase(): void
+    {
+        $data = <<<JSON
+    {"code": "sub_sweat_option_a", "family_variant": "FAMILYVARIANTA1"}
+    {"code": "root_product_model", "family": "FAMILYA", "family_variant": "FAMILYVARIANTA1"}
+JSON;
+
+        $expectedContent = <<<JSON
+{"line":1,"code":"sub_sweat_option_a","status_code":204}
+{"line":2,"code":"root_product_model","status_code":201}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -1347,6 +1347,36 @@ JSON;
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
+    public function testItCanCallEndpointWithWrongFamilyCase()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+            <<<JSON
+{
+    "code": "sub_sweat",
+    "family": "FaMiLyA",
+    "family_variant": "familyVariantA1",
+    "parent": "sweat",
+    "values": {
+        "a_text": [
+            {
+                "locale": null,
+                "scope": null,
+                "data": "My awesome text"
+            }
+        ]
+    }
+}
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
     /**
      * @param array  $expectedProductModel normalized data of the product model that should be created
      * @param string $identifier           identifier of the product that should be created

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ExternalApi/ProductModelUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ExternalApi/ProductModelUpdaterSpec.php
@@ -147,4 +147,27 @@ class ProductModelUpdaterSpec extends ObjectBehavior
             )
         )->during('update', [$productModel, $data]);
     }
+
+    public function it_can_validate_family_ignoring_case(
+        ProductModelInterface $productModel,
+        ObjectUpdaterInterface $updater,
+        Family $family,
+        FamilyVariant $familyVariant
+    ): void
+    {
+        $family->getCode()->willReturn('family_a');
+        $familyVariant->getCode()->willreturn('family_variant_a1');
+
+        $updater->update($productModel, Argument::type('array'), [])->shouldBeCalled();
+
+        $productModel->getId()->willReturn(1);
+        $productModel->getParent()->willReturn(null);
+        $productModel->getFamily()->willReturn($family);
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+
+        $this->update($productModel, [
+            'family' => 'FAMILY_A',
+            'family_variant' => 'FAMILY_VARIANT_A1',
+        ]);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductModelUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/ProductModelUpdaterSpec.php
@@ -4,6 +4,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater;
 
 use Akeneo\Pim\Enrichment\Component\Product\QuantifiedAssociation\QuantifiedAssociationsFromAncestorsFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Validator\QuantifiedAssociationsStructureValidatorInterface;
+use Akeneo\Pim\Structure\Component\Repository\FamilyVariantRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\ImmutablePropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -226,6 +227,26 @@ class ProductModelUpdaterSpec extends ObjectBehavior
         $this->shouldThrow(InvalidPropertyException::class)->during('update', [$productModel, [
             'family_variant' => 'new_family_variant'
         ]]);
+    }
+
+    public function it_ignores_case_on_family_variant(
+        ProductModelInterface $productModel,
+        ProductModelInterface $parent,
+        FamilyVariantInterface $familyVariant,
+        FamilyVariantRepositoryInterface $familyVariantRepository
+    ): void {
+        $productModel->getFamilyVariant()->willReturn(null);
+        $productModel->getParent()->willReturn($parent);
+        $parent->getFamilyVariant()->willReturn($familyVariant);
+        $familyVariant->getCode()->willreturn('family_variant');
+
+        $familyVariantRepository->findOneByIdentifier('FAMILY_VARIANT')
+            ->willReturn($familyVariant);
+        $productModel->setFamilyVariant($familyVariant)->shouldBeCalled();
+
+        $this->update($productModel, [
+            'family_variant' => 'FAMILY_VARIANT',
+        ])->shouldReturn($this);
     }
 
     function it_only_works_with_product_model(ProductInterface $product)


### PR DESCRIPTION
Backport https://github.com/akeneo/pim-enterprise-dev/pull/21494

Previously, the tested query returned

```
+'{"code":422,"message":"Property \"family\" cannot be modified, \"FaMiLyA\" given. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_product_models__code_"}}}'
```

Now, it accepts the query.