### PR TITLE
PIM-11319: fix sort asset collection attributes order for linked products

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,11 @@
 # 7.0.x
 
+# 7.0.59 (2024-03-20)
+
+## Bug fixes
+
+- PIM-11319: Fix sort order for asset collection attributes linked products
+
 # 7.0.58 (2024-03-18)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -44,9 +44,10 @@ SELECT attribute.code,
        attribute.decimals_allowed,
        attribute.backend_type,
        attribute.useable_as_grid_filter,
+       attribute.sort_order,
        COALESCE(locale_codes, JSON_ARRAY()) AS available_locale_codes
 FROM pim_catalog_attribute attribute
-    LEFT JOIN locale_specific_codes on attribute.id = attribute_id    
+    LEFT JOIN locale_specific_codes on attribute.id = attribute_id
 WHERE code IN (:attributeCodes)
 SQL;
 
@@ -72,7 +73,8 @@ SQL;
                 boolval($rawAttribute['decimals_allowed']),
                 $rawAttribute['backend_type'],
                 json_decode($rawAttribute['available_locale_codes']),
-                boolval($rawAttribute['useable_as_grid_filter'])
+                boolval($rawAttribute['useable_as_grid_filter']),
+                $rawAttribute['sort_order'] ? (int) $rawAttribute['sort_order'] : 0,
             );
         }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -20,7 +20,8 @@ final class Attribute
         private ?bool $decimalsAllowed,
         private string $backendType,
         private array $availableLocaleCodes,
-        private ?bool $useableAsGridFilter = null
+        private ?bool $useableAsGridFilter = null,
+        private ?int $sortOrder = 0,
     ) {
     }
 
@@ -87,5 +88,10 @@ final class Attribute
     public function useableAsGridFilter(): ?bool
     {
         return $this->useableAsGridFilter;
+    }
+
+    public function sortOrder(): ?int
+    {
+        return $this->sortOrder;
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add `sort_order` for Attribute in order to retrieve the right sorting in the asset collection attributes for `Linked Products` section.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
