### PR TITLE
PIM-11452: Forbid the usage of non-breakable space in product identifier and product model code

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11452: Forbid the usage of non-breaking space in product identifier and product model code
+
 # 7.0.60 (2024-03-28)
 
 # 7.0.59 (2024-03-26)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -21,7 +21,7 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
             - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsUuid4: ~
         identifier:
             - Regex:
-                pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
+                pattern: '/^(?!\s)[^,;]+(?<!\s)$/u'
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'
             - Regex:
                 pattern: '/[\r\n]/'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/productmodel.yml
@@ -15,7 +15,7 @@ Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel:
             - NotBlank:
                 message: 'product_model.code.not_blank.message'
             - Regex:
-                pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
+                pattern: '/^(?!\s)[^,;]+(?<!\s)$/u'
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'
             - Regex:
                 pattern: '/[\r\n]/'

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -81,6 +81,18 @@ class ProductIdentifierValidationIntegration extends TestCase
         );
     }
 
+    public function testItCannotCreateAnIdentifierWithNonBreakingSpaceCharacter()
+    {
+        $correctProduct = $this->createProduct('sku-001 ');
+        $violations = $this->validateProduct($correctProduct);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            $violations->get(0)->getMessage(),
+            'This field should not contain any comma or semicolon or leading/trailing space'
+        );
+    }
+
     public function testItCanCreateProductWithoutIdentifier()
     {
         $correctProduct = $this->createProduct('sku-001');


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-11452

Backport of https://github.com/akeneo/pim-enterprise-dev/pull/22243

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
