### PR TITLE
PIM-11478: Fix duplicate creation buttons in variant navigation dropdowns

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- PIM-11478: Fix duplicate creation buttons in variant navigation dropdowns
+
 # 7.0.61 (2024-04-08)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/variant-navigation.js
@@ -170,11 +170,10 @@ define([
      * @param {Element} dropDown
      */
     addSelect2Footer: function (dropDown) {
-      $('#select2-drop .select2-drop-footer').remove();
-
       const targetLevel = dropDown[0].dataset.level;
       this.getEntityParentCode(targetLevel).then(parentCode => {
         this.isVariantProduct(parentCode).then(async isVariantProduct => {
+          $('#select2-drop .select2-drop-footer').remove();
           if (!(await this.isCreationGranted(isVariantProduct))) {
             return;
           }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

When quickly opening and closing variant navigation dropdowns in product model or variant product edit form, it could happen that multiple "Add new" buttons were added to the dropdown (especially in case of slow network, of if the product form is huge (hundreds of fields)

![image-20240416-182756](https://github.com/akeneo/pim-community-dev/assets/5301298/3e5af6db-4427-4455-9760-8ebb6812b900)



**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
