### PR TITLE
Fix make commands to run project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ front-packages/akeneo-design-system/lib
 /.env.local
 /.env.local.php
 /.env.*.local
+
+# Ignore IDE files
+.idea
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,10 @@ fix-cs-back:
 var/cache/dev:
 	APP_ENV=dev make cache
 
+.PHONY: composer
+composer:
+	$(DOCKER_COMPOSE) run --rm php composer install
+
 .PHONY: cache
 cache:
 	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache && $(PHP_RUN) bin/console cache:warmup
@@ -148,7 +152,9 @@ pim-test:
 .PHONY: pim-dev
 pim-dev:
 	APP_ENV=dev $(MAKE) up
+	APP_ENV=dev $(MAKE) composer
 	APP_ENV=dev $(MAKE) cache
+	$(MAKE) node_modules
 	$(MAKE) assets
 	$(MAKE) css
 	$(MAKE) front-packages
@@ -159,7 +165,9 @@ pim-dev:
 .PHONY: pim-prod
 pim-prod:
 	APP_ENV=prod $(MAKE) up
+	APP_ENV=prod $(MAKE) composer
 	APP_ENV=prod $(MAKE) cache
+	$(MAKE) node_modules
 	$(MAKE) assets
 	$(MAKE) css
 	$(MAKE) front-packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       discovery.type: 'single-node'
       xpack.security.enabled: 'false'
       indices.id_field_data.enabled: 'true'
+      cluster.routing.allocation.disk.threshold_enabled: false
     ports:
       - '${DOCKER_PORT_ELASTICSEARCH:-9210}:9200'
     networks:


### PR DESCRIPTION
## Overview
This PR fixes running project according to the [installation guide](https://docs.akeneo.com/master/install_pim/docker/installation_docker.html).

### Details
- Added missing `compose install` and `yarn install` calls for `pim-dev` and `pim-prod` make shortcuts.
- Fixed ElasticSearch `flood stage disk watermark [95%] exceeded` issue by disabling `cluster.routing.allocation.disk.threshold_enabled`.
- Added `.gitignore` exclusion for IDE files.
