### PR TITLE
Fix CI 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             - run:
                   name: Merge all files
                   command: |
-                      yq eval-all '. as $item ireduce ({}; . *+ $item )' .circleci/*/*.yml .circleci/*/*/*.yml .circleci/*/*/*/*.yml > .circleci/merged_config.yml
+                      yq eval-all '. as $item ireduce ({}; . *+ $item )' .circleci/settings.yml .circleci/*/*.yml .circleci/*/*/*.yml .circleci/*/*/*/*.yml > .circleci/merged_config.yml
                       cat .circleci/merged_config.yml
             -   path-filtering/set-parameters:
                     base-revision: master

--- a/.circleci/docker-compose.override.yml.dist
+++ b/.circleci/docker-compose.override.yml.dist
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   mysql:
     tmpfs:

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -1,4 +1,4 @@
-executor-machine: &executor-machine 'ubuntu-2004:2022.04.1'
+executor-machine: &executor-machine
 
 orbs:
   git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0

--- a/.circleci/jobs/features/catalogs/test_back_catalogs_ce.yml
+++ b/.circleci/jobs/features/catalogs/test_back_catalogs_ce.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     test_back_catalogs_ce:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
             docker_layer_caching: true
         steps:
             -   attach_workspace:

--- a/.circleci/jobs/features/catalogs/test_back_catalogs_ee.yml
+++ b/.circleci/jobs/features/catalogs/test_back_catalogs_ee.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     test_back_catalogs_ee:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
             docker_layer_caching: true
         parameters:
             notify:

--- a/.circleci/jobs/features/catalogs/test_front_catalogs_ce.yml
+++ b/.circleci/jobs/features/catalogs/test_front_catalogs_ce.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     test_front_catalogs_ce:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
             docker_layer_caching: true
         steps:
             -   attach_workspace:

--- a/.circleci/jobs/features/catalogs/test_front_catalogs_ee.yml
+++ b/.circleci/jobs/features/catalogs/test_front_catalogs_ee.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     test_front_catalogs_ee:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
             docker_layer_caching: true
         parameters:
             notify:

--- a/.circleci/jobs/features/catalogs/test_performance_catalogs_ce.yml
+++ b/.circleci/jobs/features/catalogs/test_performance_catalogs_ce.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     test_performance_catalogs_ce:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
             docker_layer_caching: true
         steps:
             -   attach_workspace:

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -1,4 +1,4 @@
-executor-machine: &executor-machine 'ubuntu-2004:2022.04.1'
+executor-machine: &executor-machine
 
 jobs:
     test_front_lint_connectivity:

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -1,4 +1,4 @@
-executor-machine: &executor-machine 'ubuntu-2004:2022.04.1'
+executor-machine: &executor-machine
 
 jobs:
     test_back_static_and_acceptance:

--- a/.circleci/jobs/install_back_dependencies.yml
+++ b/.circleci/jobs/install_back_dependencies.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     install_back_dependencies:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
         parameters:
             edition:
                 description: either "ce" or "ee"

--- a/.circleci/jobs/install_front_dependencies.yml
+++ b/.circleci/jobs/install_front_dependencies.yml
@@ -1,7 +1,9 @@
+executor-machine: &executor-machine
+
 jobs:
     install_front_dependencies:
         machine:
-            image: 'ubuntu-2004:2022.04.1'
+            image: *executor-machine
         parameters:
             edition:
                 description: either "ce" or "ee"

--- a/.circleci/settings.yml
+++ b/.circleci/settings.yml
@@ -1,0 +1,1 @@
+executor-machine: &executor-machine "ubuntu-2204:current"

--- a/docker-compose-cypress.yml
+++ b/docker-compose-cypress.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   cypress:
     build:

--- a/docker-compose.override-osx.yml
+++ b/docker-compose.override-osx.yml
@@ -1,8 +1,6 @@
 # Rename this file into docker-compose.override.yml:
 # mv docker-compose.override-osx.yml docker-compose.override.yml
 
-version: '3.7'
-
 services:
   php:
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   php:
     image: 'akeneo/pim-php-dev:8.1'


### PR DESCRIPTION
**Description**

- Update config for circle CI to remove image `ubuntu-2004:2022.04.1` (unavailable).
- Remove warning for docker compose version