### PR TITLE
AST-551: backport fix for Product thumbnail using localizable scopable Asset Collection as main image

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -87,6 +87,10 @@
 
   &-imageWrapper {
     display: flex;
+    width: @imageSize + 2px;
+    height: @imageSize + 2px;
+    flex-basis: @imageSize + 2px;
+    flex-shrink: 0;
   }
 
   &-image {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/TitleContainer.less
@@ -85,6 +85,10 @@
     opacity: 1;
   }
 
+  &-imageWrapper {
+    display: flex;
+  }
+
   &-image {
     margin: auto;
     width: 100%;

--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToProductGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToProductGridListener.php
@@ -71,6 +71,8 @@ class AddParametersToProductGridListener extends AddParametersToGridListener
 
         $dataScope = $this->getScope();
         $queryParameters['scopeCode'] = $dataScope;
+        // ensure dataChannel is correctly provided for building legacy results (eg. with associated product datagrid)
+        $queryParameters['dataChannel'] = $dataScope;
 
         return $queryParameters;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToProductGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToProductGridListener.php
@@ -54,7 +54,9 @@ class AddParametersToProductGridListener extends AddParametersToGridListener
      */
     protected function getRequest(): ?Request
     {
-        return $this->requestStack->getCurrentRequest();
+        // The Datagrid main request carries the filter values (including catalog locale and channel)
+        // The sub request used for loading grid data is stacked (returned by getCurrentRequest) does not use the exact same parameters
+        return $this->requestStack->getMainRequest();
     }
 
     /**


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

Backport the components related to the CE from the fix AST-551](https://akeneo.atlassian.net/browse/AST-551)
Here are the related PRs:
- https://github.com/akeneo/pim-enterprise-dev/pull/24860
- https://github.com/akeneo/pim-enterprise-dev/pull/24930

Linked to the EE pul request: https://github.com/akeneo/pim-enterprise-dev/pull/24990

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
