### PR TITLE
SQUD 215 Backport 'akeneo:pim:zero-downtime-recreate-product-and-product-model-index' command in 7.0

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZeroDowntimeRecreateProductAndProductModelIndexCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZeroDowntimeRecreateProductAndProductModelIndexCommand.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command;
+
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\UpdateIndexMappingWithoutDowntime;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @copyright 2024 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ZeroDowntimeRecreateProductAndProductModelIndexCommand extends Command
+{
+    private const DEFAULT_BATCH_SIZE = 1000;
+
+    protected static $defaultName = 'akeneo:pim:zero-downtime-recreate-product-and-product-model-index';
+    protected static $defaultDescription = <<<EOL
+        Zero-downtime reindexing of product and product models. 
+        
+        Reindex all documents in the product and product model index using Elasticsearch's Reindex API.
+        This allows removing "ghost" fields from the new index and prevents the index from reaching the
+        `index.mapping.total_fields.limit` or `index.mapping.nested_fields.limit` limits
+        EOL;
+
+    public function __construct(
+        private readonly Client $client,
+        private readonly UpdateIndexMappingWithoutDowntime $updateIndexMappingWithoutDowntime,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct(self::$defaultName);
+    }
+
+    protected function configure()
+    {
+        $this
+            ->addOption(
+                'batch-size',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Number of products to index per batch',
+                self::DEFAULT_BATCH_SIZE
+            );
+    }
+
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if ($input->isInteractive()) {
+            $io = new SymfonyStyle($input, $output);
+            $io->warning(
+                <<<EOL
+            This command will recreate the current product and product model index, and will copy every document as is.
+            It is only useful to reset the index's mapping configuration (fields limit) and should not be used to
+            refresh the content of the documents.
+            EOL
+            );
+            if (!$io->confirm('Do you want to continue?', false)) {
+                $output->writeln('<info>Product and product model reindexing cancelled</info>');
+
+                return Command::SUCCESS;
+            }
+        }
+
+        $batchSize = (int) $input->getOption('batch-size') ?: self::DEFAULT_BATCH_SIZE;
+
+        $indexConfiguration = $this->client->getConfigurationLoader()->load();
+        $currentIndexAlias = $this->client->getIndexName();
+        $newIndexName = \sprintf('%s_%s', $currentIndexAlias, Uuid::uuid4()->toString());
+        $temporaryAliasName = \sprintf('%s_alias', $newIndexName);
+
+        $this->logger->notice(
+            'Recreating product and product model index',
+            [
+                'source_alias' => $currentIndexAlias,
+                'target_temporary_alias' => $temporaryAliasName,
+                'target_index_name' => $newIndexName,
+            ]
+        );
+
+        $this->updateIndexMappingWithoutDowntime->execute(
+            sourceIndexAlias: $currentIndexAlias,
+            destinationIndexAlias: $temporaryAliasName,
+            destinationIndexName: $newIndexName,
+            indexConfiguration: $indexConfiguration,
+            findUpdatedDocumentQuery: static fn (\DateTimeImmutable $referenceDatetime): array => [
+                'range' => [
+                    'updated' => ['gt' => $referenceDatetime->format('c')]
+                ],
+            ],
+            batchSize: $batchSize,
+        );
+
+        $this->logger->notice('Operation successful');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
@@ -45,3 +45,11 @@ services:
             - '@pim_catalog.query.product_and_product_model_query_builder_factory'
         tags:
             - { name: console.command }
+
+    Akeneo\Pim\Enrichment\Bundle\Command\ZeroDowntimeRecreateProductAndProductModelIndexCommand:
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\UpdateIndexMappingWithoutDowntime'
+            - '@logger'
+        tags:
+            - { name: console.command }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMappingWithoutDowntime.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMappingWithoutDowntime.php
@@ -26,7 +26,8 @@ final class UpdateIndexMappingWithoutDowntime
         string $destinationIndexAlias,
         string $destinationIndexName,
         IndexConfiguration $indexConfiguration,
-        \Closure $findUpdatedDocumentQuery
+        \Closure $findUpdatedDocumentQuery,
+        ?int $batchSize = null,
     ): void {
         $indexToMigrateDoesNotHaveAlias = $this->indexToMigrateDoesNotHaveAlias($sourceIndexAlias);
         if ($indexToMigrateDoesNotHaveAlias) {
@@ -39,7 +40,8 @@ final class UpdateIndexMappingWithoutDowntime
         $lastReferenceDatetime = $this->moveAllDocuments(
             $sourceIndexAlias,
             $destinationIndexAlias,
-            $findUpdatedDocumentQuery
+            $findUpdatedDocumentQuery,
+            $batchSize,
         );
 
         $this->resetIndexSettings($destinationIndexName, $sourceIndexName);
@@ -88,7 +90,8 @@ final class UpdateIndexMappingWithoutDowntime
     private function moveAllDocuments(
         string $sourceIndexAlias,
         string $targetIndexAlias,
-        \Closure $findUpdatedDocumentQuery
+        \Closure $findUpdatedDocumentQuery,
+        ?int $batchSize = null,
     ): \DateTimeImmutable {
         $lastReferenceDatetime = $this->clock->now()->setTimestamp(0);
         do {
@@ -97,7 +100,8 @@ final class UpdateIndexMappingWithoutDowntime
                 $sourceIndexAlias,
                 $targetIndexAlias,
                 $lastReferenceDatetime,
-                $findUpdatedDocumentQuery
+                $findUpdatedDocumentQuery,
+                $batchSize
             );
 
             $lastReferenceDatetime = $nextUpdateTime;
@@ -110,12 +114,14 @@ final class UpdateIndexMappingWithoutDowntime
         string $sourceIndexAlias,
         string $targetIndexAlias,
         \DateTimeImmutable $referenceDatetime,
-        \Closure $findUpdatedDocumentQuery
+        \Closure $findUpdatedDocumentQuery,
+        ?int $batchSize = null,
     ): int {
         return $this->migrationClient->reindex(
             $sourceIndexAlias,
             $targetIndexAlias,
-            $findUpdatedDocumentQuery($referenceDatetime)
+            $findUpdatedDocumentQuery($referenceDatetime),
+            $batchSize,
         );
     }
 

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigration.php
@@ -34,7 +34,7 @@ final class ClientMigration implements ClientMigrationInterface
         return \array_keys($aliases);
     }
 
-    public function reindex(string $sourceIndexAlias, string $targetIndexAlias, array $query)
+    public function reindex(string $sourceIndexAlias, string $targetIndexAlias, array $query, ?int $batchSize = null)
     {
         $reindexResponse = $this->client->reindex([
             'wait_for_completion' => true,
@@ -42,6 +42,7 @@ final class ClientMigration implements ClientMigrationInterface
                 "source" => [
                     "index" => $sourceIndexAlias,
                     "query" => $query,
+                    "size" => (null != $batchSize) ? $batchSize : 1000
                 ],
                 "dest" => [
                     "index" => $targetIndexAlias,

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigrationInterface.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigrationInterface.php
@@ -14,7 +14,7 @@ interface ClientMigrationInterface
     public function getIndexNameFromAlias(string $indexAlias): array;
     public function aliasExist(string $indexAlias): bool;
     public function createAlias(string $indexAlias, string $indexName): void;
-    public function reindex(string $sourceIndexAlias, string $targetIndexAlias, array $query);
+    public function reindex(string $sourceIndexAlias, string $targetIndexAlias, array $query, ?int $batchSize = null);
     public function removeIndex(string $indexName): void;
     public function getIndexSettings(string $indexName): array;
     public function putIndexSetting(string $indexName, array $indexSettings);

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/UpdateIndexMappingWithoutDowntimeSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/UpdateIndexMappingWithoutDowntimeSpec.php
@@ -104,6 +104,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $firstDatetime->getTimestamp()],
                 ]
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(10);
 
         $clientMigration->reindex(
@@ -114,6 +115,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()],
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration
@@ -136,7 +138,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $datetimeAfterSwitch->modify('- 1second')->getTimestamp()],
                 ],
-            ]
+            ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration->removeIndex(self::INDEX_NAME_TO_MIGRATE)->shouldBeCalledOnce();
@@ -150,7 +153,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $referenceDatetime->getTimestamp()]
                 ],
-            ]
+            ],
         );
     }
 
@@ -206,6 +209,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $firstDatetime->getTimestamp()],
                 ]
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(10);
 
         $clientMigration->reindex(
@@ -216,6 +220,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()],
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration
@@ -238,7 +243,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $datetimeAfterSwitch->modify('- 1second')->getTimestamp()],
                 ],
-            ]
+            ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration->removeIndex(self::INDEX_ALIAS_TO_MIGRATE)->shouldBeCalledOnce();
@@ -253,7 +259,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $referenceDatetime->getTimestamp()]
                 ],
-            ]
+            ],
         );
     }
 
@@ -308,7 +314,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $firstDatetime->getTimestamp()],
                 ],
-            ]
+            ],
+            null,
         )->shouldBeCalledOnce()->willReturn(10);
 
         $clientMigration->reindex(
@@ -319,6 +326,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()],
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(2);
 
         $clientMigration->reindex(
@@ -328,7 +336,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $datetimeAfterSecondIndexation->modify('- 1second')->getTimestamp()]
                 ],
-            ]
+            ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration
@@ -351,7 +360,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $datetimeAfterSwitch->modify('- 1second')->getTimestamp()]
                 ],
-            ]
+            ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration->removeIndex(self::INDEX_NAME_TO_MIGRATE)->shouldBeCalledOnce();
@@ -365,7 +375,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $referenceDatetime->getTimestamp()]
                 ],
-            ]
+            ],
         );
     }
 
@@ -419,6 +429,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $firstDatetime->getTimestamp()]
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(10);
 
         $clientMigration->reindex(
@@ -429,6 +440,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()]
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration
@@ -452,6 +464,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                     'updated_at' => ['gt' => $datetimeAfterSwitch->modify('- 1second')->getTimestamp()]
                 ],
             ],
+            null,
         )->shouldBeCalledOnce()->willReturn(1);
 
         $clientMigration->removeIndex(self::INDEX_NAME_TO_MIGRATE)->shouldBeCalledOnce();
@@ -465,7 +478,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $referenceDatetime->getTimestamp()]
                 ],
-            ]
+            ],
         );
     }
 
@@ -518,7 +531,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $firstDatetime->getTimestamp()],
                 ],
-            ]
+            ],
+            null
         )->shouldBeCalledOnce()->willReturn(10);
 
         $clientMigration->reindex(
@@ -528,7 +542,8 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
                 'range' => [
                     'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()],
                 ],
-            ]
+            ],
+            null
         )->shouldBeCalledOnce()->willReturn(0);
 
         $clientMigration


### PR DESCRIPTION
Backport of command akeneo:pim:zero-downtime-recreate-product-and-product-model-index to remap without downtime product and product model indexes for Flex