### PR TITLE
CEQIF-464: Parametrize the batch size during completeness calculation

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ComputeAndPersistProductCompletenesses
 {
-    private const CHUNK_SIZE = 1000;
+    private const DEFAULT_CHUNK_SIZE = 1000;
 
     public function __construct(
         private CompletenessCalculator $completenessCalculator,
@@ -32,7 +32,8 @@ class ComputeAndPersistProductCompletenesses
         private EventDispatcherInterface $eventDispatcher,
         private Clock $clock,
         private TokenStorageInterface $tokenStorage,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly int $chunkSize = self::DEFAULT_CHUNK_SIZE,
     ) {
     }
 
@@ -41,7 +42,7 @@ class ComputeAndPersistProductCompletenesses
      */
     public function fromProductUuids(array $productUuids): void
     {
-        foreach (array_chunk($productUuids, self::CHUNK_SIZE) as $uuidsChunk) {
+        foreach (array_chunk($productUuids, $this->chunkSize) as $uuidsChunk) {
             $previousCompletenessCollections = $this->getProductCompletenesses->fromProductUuids($uuidsChunk);
             $completenessCollections = $this->completenessCalculator->fromProductUuids($uuidsChunk);
             $this->saveProductCompletenesses->saveAll($completenessCollections);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
@@ -1,3 +1,6 @@
+parameters:
+    pim_enrich.product.completeness_calculation.batch_size: 1000
+
 services:
     pim_catalog.completeness.calculator:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator'
@@ -16,6 +19,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Product\Domain\Clock'
             - '@security.token_storage'
             - '@logger'
+            - '%pim_enrich.product.completeness_calculation.batch_size%'
 
     pim_catalog.completeness.missing_required_attributes_calculator:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Completeness\MissingRequiredAttributesCalculator'


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

With some catalog configurations (e.g a catalog with a lot of enabled locales), the default completeness calculation batch size is too high, because MySQL is not able to handle such an amount of rows (especially for the SqlGetCompletenesses query). This issue does not exist anymore in Serenity, because the completeness table structure has been completely reworked; however it is not possible to backport these changes to 7.0, as it implies a big migration (+ multiple BC breaks)

This PR will allow clients to define (and finetune) this batch size to get better performances (lower batch size = more SQL queries, but executed way more quickly) 