### PR TITLE
Update ItemStep write method to early return if the list is empty.

### DIFF
--- a/src/Akeneo/Tool/Component/Batch/Step/ItemStep.php
+++ b/src/Akeneo/Tool/Component/Batch/Step/ItemStep.php
@@ -114,10 +114,8 @@ class ItemStep extends AbstractStep implements TrackableStepInterface, LoggerAwa
             }
 
             if ($batchCount >= $this->batchSize) {
-                if (!empty($itemsToWrite)) {
-                    $this->write($itemsToWrite);
-                    $itemsToWrite = [];
-                }
+                $this->write($itemsToWrite);
+                $itemsToWrite = [];
 
                 $this->updateProcessedItems($batchCount);
                 $this->dispatchStepExecutionEvent(EventInterface::ITEM_STEP_AFTER_BATCH, $stepExecution);
@@ -137,9 +135,7 @@ class ItemStep extends AbstractStep implements TrackableStepInterface, LoggerAwa
             }
         }
 
-        if (!empty($itemsToWrite)) {
-            $this->write($itemsToWrite);
-        }
+        $this->write($itemsToWrite);
 
         if ($batchCount > 0) {
             $this->updateProcessedItems($batchCount);
@@ -228,6 +224,10 @@ class ItemStep extends AbstractStep implements TrackableStepInterface, LoggerAwa
      */
     protected function write($processedItems)
     {
+        if (empty($processedItems)) {
+            return;
+        }
+
         try {
             $this->writer->write($processedItems);
         } catch (InvalidItemException $e) {


### PR DESCRIPTION
Update ItemStep write method to early return if the list is empty.

Useful for custom jobs, where the output must be empty. Currently the item step method has to rewritten to allow one to write at least one time, instead of rewriting only the write method

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
