### PR TITLE
[CEQIF-640] Remove duplicate product delete filter

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -144,7 +144,6 @@ datagrid:
                 type: mass_delete
                 label: pim_common.delete
                 entity_name: product
-                acl_resource: pim_enrich_product_remove
                 handler: product_mass_delete
                 className: 'AknButton AknButton--important AknButtonList-item'
                 messages:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This PR removes a check in the yml file for the delete button in the product grid. This check only determines whether the delete button should be available for users who have the "delete products" permission, and does not not determine whether it should be available for those with the "delete product models" permission. Both are checked at determining the visibility of the button in the delete-product-action.js file at line 41, so this additional check is unnecessary, and prevents users with the "delete product models" permission from deleting product models in the product grid if they do not have the "delete products" permission.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
