### PR TITLE
Upgrade to PHP 8.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   php:
-    image: 'akeneo/pim-php-dev:8.2'
+    image: 'akeneo/pim-php-dev:8.3'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
       COMPOSER_HOME: '/var/www/.composer'
@@ -23,7 +23,7 @@ services:
       - 'pim'
 
   httpd:
-    image: 'akeneo/pim-php-dev:8.2'
+    image: 'akeneo/pim-php-dev:8.3'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
       BEHAT_TMPDIR: '/srv/pim/var/cache/tmp'


### PR DESCRIPTION
## Summary
- Upgrade Docker images from PHP 8.2 to 8.3
- No code changes required

## PHP 8.3 Breaking Changes Checked

| Issue | Status |
|-------|--------|
| `get_class()` without arguments | ✅ Not used |
| `get_parent_class()` without arguments | ✅ Not used |
| `assert_options()` | ✅ Not used |
| String increment `$str++` | ✅ Not used |
| `range()` edge cases | ✅ No problematic usage |
| `proc_get_status()` behavior change | ✅ N/A |

## Files changed
- `docker-compose.yml` - PHP 8.2 → 8.3

## Test plan
- [ ] `docker-compose up -d` starts with PHP 8.3
- [ ] Application loads without errors
- [ ] No deprecation warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)