### PR TITLE
Upgrade Dockerfile to PHP 8.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,35 +24,35 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     apt-get --yes install imagemagick \
         libmagickcore-6.q16-6-extra \
         ghostscript \
-        php8.1-fpm \
-        php8.1-cli \
-        php8.1-intl \
-        php8.1-opcache \
-        php8.1-mysql \
-        php8.1-zip \
-        php8.1-xml \
-        php8.1-gd \
-        php8.1-grpc \
-        php8.1-curl \
-        php8.1-mbstring \
-        php8.1-bcmath \
-        php8.1-imagick \
-        php8.1-apcu \
-        php8.1-exif \
-        php8.1-memcached \
+        php8.4-fpm \
+        php8.4-cli \
+        php8.4-intl \
+        php8.4-opcache \
+        php8.4-mysql \
+        php8.4-zip \
+        php8.4-xml \
+        php8.4-gd \
+        php8.4-grpc \
+        php8.4-curl \
+        php8.4-mbstring \
+        php8.4-bcmath \
+        php8.4-imagick \
+        php8.4-apcu \
+        php8.4-exif \
+        php8.4-memcached \
         openssh-client \
         aspell \
         aspell-en aspell-es aspell-de aspell-fr && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/sbin/php-fpm8.1 /usr/local/sbin/php-fpm && \
+    ln -s /usr/sbin/php-fpm8.4 /usr/local/sbin/php-fpm && \
     usermod --uid 1000 www-data && groupmod --gid 1000 www-data && \
     mkdir /srv/pim && \
-    sed -i "s#listen = /run/php/php8.1-fpm.sock#listen = 9000#g" /etc/php/8.1/fpm/pool.d/www.conf && \
+    sed -i "s#listen = /run/php/php8.4-fpm.sock#listen = 9000#g" /etc/php/8.4/fpm/pool.d/www.conf && \
     mkdir -p /run/php
 
-COPY docker/build/akeneo.ini /etc/php/8.1/cli/conf.d/99-akeneo.ini
-COPY docker/build/akeneo.ini /etc/php/8.1/fpm/conf.d/99-akeneo.ini
+COPY docker/build/akeneo.ini /etc/php/8.4/cli/conf.d/99-akeneo.ini
+COPY docker/build/akeneo.ini /etc/php/8.4/fpm/conf.d/99-akeneo.ini
 
 CMD ["/usr/bin/supervisord", "-c", "docker/supervisord.conf"]
 
@@ -73,16 +73,16 @@ RUN apt-get update && \
         default-mysql-client \
         git \
         perceptualdiff \
-        php8.1-xdebug \
+        php8.4-xdebug \
         procps \
         unzip &&\
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY docker/build/xdebug.ini /etc/php/8.1/cli/conf.d/99-akeneo-xdebug.ini
-COPY docker/build/xdebug.ini /etc/php/8.1/fpm/conf.d/99-akeneo-xdebug.ini
-COPY docker/build/blackfire.ini /etc/php/8.1/cli/conf.d/99-akeneo-blackfire.ini
-COPY docker/build/blackfire.ini /etc/php/8.1/fpm/conf.d/99-akeneo-blackfire.ini
+COPY docker/build/xdebug.ini /etc/php/8.4/cli/conf.d/99-akeneo-xdebug.ini
+COPY docker/build/xdebug.ini /etc/php/8.4/fpm/conf.d/99-akeneo-xdebug.ini
+COPY docker/build/blackfire.ini /etc/php/8.4/cli/conf.d/99-akeneo-blackfire.ini
+COPY docker/build/blackfire.ini /etc/php/8.4/fpm/conf.d/99-akeneo-blackfire.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 RUN chmod +x /usr/local/bin/composer


### PR DESCRIPTION
## Summary
- Update Docker image from PHP 8.1 to PHP 8.4
- Change all php8.1-* packages to php8.4-*
- Update php-fpm symlink from 8.1 to 8.4
- Update config paths from /etc/php/8.1/ to /etc/php/8.4/

## How to build the image

```bash
docker build -t akeneo/pim-php-dev:8.4 .
```

## How to publish the image

```bash
docker login
docker push akeneo/pim-php-dev:8.4
```

## Test plan
- [ ] Build Docker image locally: `docker build -t akeneo/pim-php-dev:8.4 .`
- [ ] Verify PHP version: `docker run --rm akeneo/pim-php-dev:8.4 php -v`
- [ ] Run application with the new image

🤖 Generated with [Claude Code](https://claude.com/claude-code)