### PR TITLE
Community Edition Tech Refresh - New Main

### DIFF
--- a/.circleci/workflows/pull_request.yml
+++ b/.circleci/workflows/pull_request.yml
@@ -7,50 +7,6 @@ workflows:
             not:
                 equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         jobs:
-            - ready_to_build?:
-                  type: approval
-                  filters:
-                      branches:
-                          ignore:
-                              - "7.0"
-            - checkout_ee:
-                  requires:
-                      - ready_to_build?
-            - build_dev:
-                  path_to_front_packages: vendor/akeneo/pim-community-dev/front-packages
-                  requires:
-                      - checkout_ee
-            - test_database:
-                  requires:
-                      - build_dev
-            - test_back_static_and_acceptance:
-                  requires:
-                      - build_dev
-            - test_front_static_acceptance_and_integration:
-                  requires:
-                      - build_dev
-            - test_back_phpunit:
-                  requires:
-                      - build_dev
-            - test_onboarder_bundle:
-                  requires:
-                      - build_dev
-            - test_back_data_migrations:
-                  requires:
-                      - test_back_static_and_acceptance
-                      - test_front_static_acceptance_and_integration
-                      - test_back_phpunit
-            - test_back_behat_legacy:
-                  requires:
-                      - test_back_static_and_acceptance
-                      - test_front_static_acceptance_and_integration
-                      - test_back_phpunit
-            - test_back_catalogs_ee:
-                  requires:
-                      - build_dev
-                  notify: true
-                  context:
-                      - octopus-slack
             - ready_to_build_only_ce?:
                   type: approval
                   filters:
@@ -94,9 +50,6 @@ workflows:
 
             - pull_request_success:
                   requires:
-                      - test_back_behat_legacy
-                      - test_back_data_migrations
-                      - test_onboarder_bundle
-                      - test_database
                       - test_back_behat_legacy_ce
-                      - test_back_catalogs_ee
+                      - test_back_data_migrations_ce
+                      - cypress_sanity_checks_ce


### PR DESCRIPTION
## Summary
Phase #0 of the Community Edition Tech Refresh initiative.

This PR removes EE-related CI jobs from the pull_request workflow to make CE standalone.

## Changes
- Remove EE tests from `.circleci/workflows/pull_request.yml`
- Keep only CE tests (`ready_to_build_only_ce?` workflow)

## Removed EE jobs
- `ready_to_build?` (EE approval gate)
- `checkout_ee`
- `build_dev` (EE)
- `test_database`
- `test_onboarder_bundle`
- `test_back_catalogs_ee`
- All EE test jobs (static, phpunit, behat, data_migrations)

## Test plan
- [ ] CE-only CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)