### PR TITLE
fix: Harden UTC Doctrine types for MySQL 8.4 datetime

### DIFF
--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeImmutableType.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeImmutableType.php
@@ -37,7 +37,7 @@ class UTCDateTimeImmutableType extends DateTimeImmutableType
             $platform->getDateTimeFormatString(),
             $value,
             self::getUtc()
-        );
+        ) ?: \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', $value, self::getUtc());
 
         if (!$converted) {
             throw ConversionException::conversionFailedFormat(

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeType.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeType.php
@@ -45,14 +45,14 @@ class UTCDateTimeType extends DateTimeType
             $platform->getDateTimeFormatString(),
             $value,
             (self::$utc) ? self::$utc : (self::$utc = new \DateTimeZone('UTC'))
-        );
-
-        $serverTimezone = date_default_timezone_get();
-        $val->setTimezone(new \DateTimeZone($serverTimezone));
+        ) ?: \DateTime::createFromFormat('Y-m-d H:i:s.u', $value, (self::$utc) ? self::$utc : (self::$utc = new \DateTimeZone('UTC')));
 
         if (!$val) {
             throw ConversionException::conversionFailed($value, $this->getName());
         }
+
+        $serverTimezone = date_default_timezone_get();
+        $val->setTimezone(new \DateTimeZone($serverTimezone));
 
         $errors = $val->getLastErrors();
 


### PR DESCRIPTION
## Harden UTCDateTimeType and UTCDateTimeImmutableType for MySQL 8.4 compatibility

Related to #20624 (Add MySQL 8.4 support: fix GREATEST() DATETIME type promotion).

### Why

MySQL 8.0 reaches End of Life in **April 2026**. When upgrading to MySQL 8.4, existing database schemas with `DATETIME` (precision 0) columns continue to work correctly. MySQL 8.4 does not change the default column precision and returns values without microseconds for `DATETIME(0)` columns.

However, MySQL 8.4 changed its **type coercion rules for SQL expressions**. When a SQL expression mixes `DATETIME` and `INTEGER` types (e.g. `GREATEST(datetime_col, COALESCE(nullable_col, 0))`), MySQL 8.4 promotes the result to `DATETIME(6)`, returning values with microsecond precision like `2026-03-20 12:08:24.000000`. MySQL 8.0 returned plain `DATETIME` in the same scenario.

### What it solves

`UTCDateTimeImmutableType` and `UTCDateTimeType` use `DateTimeImmutable::createFromFormat('Y-m-d H:i:s', ...)` to parse database values. PHP strictly rejects the trailing `.000000` as "Trailing data" and returns `false`, throwing:
```
Could not convert database value "2026-03-23 12:08:24.000000" to Doctrine Type datetime_immutable. Expected format: Y-m-d H:i:s
```
This PR adds a fallback to `Y-m-d H:i:s.u` format when the standard format fails to parse. This:

- Provides a safety net for any current or future SQL expressions that produce `DATETIME(6)` values on MySQL 8.4
- Enables support for `DATETIME(6)` columns, allowing schemas that require microsecond precision to work with these Doctrine types without custom overrides

### Files Changed

- `src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeImmutableType.php`
- `src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeType.php`