### PR TITLE
Fix system user display in history

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
@@ -108,7 +108,11 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             $user = $this->userManager->findUserByUsername($author);
 
             if (null === $user) {
-                $userName = sprintf('%s - %s', $author, $this->translator->trans('pim_user.user.removed_user'));
+                if ($author === UserInterface::SYSTEM_USER_NAME) {
+                    $userName = $this->translator->trans('pim_user.user.system_user');
+                } else {
+                    $userName = sprintf('%s - %s', $author, $this->translator->trans('pim_user.user.removed_user'));
+                }
             } else {
                 Assert::isInstanceOf($user, UserInterface::class);
                 $userName = sprintf('%s %s', $user->getFirstName(), $user->getLastName());

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
@@ -64,6 +64,7 @@ pim_user:
             business_unit.title:         Business Units
             email_synchronization.title: Email synchronization settings
         removed_user: Removed user
+        system_user: System
         login:
             username_or_email: Username or Email
             remember_me: Remember me on this computer

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
@@ -171,4 +171,45 @@ class VersionNormalizerSpec extends ObjectBehavior
             'pending'     => false
         ]);
     }
+
+    function it_normalize_versions_with_system_user(
+        $userManager,
+        $translator,
+        $datetimePresenter,
+        $userContext,
+        LocaleAwareInterface $localeAware,
+        Version $version
+    ) {
+        $versionTime = new \DateTime();
+
+        $version->getId()->willReturn(12);
+        $version->getResourceId()->willReturn(112);
+        $version->getSnapshot()->willReturn('a nice snapshot');
+        $version->getChangeset()->willReturn(['text' => 'the changeset']);
+        $version->getContext()->willReturn(['locale' => 'en_US', 'channel' => 'mobile']);
+        $version->getVersion()->willReturn(12);
+        $version->getLoggedAt()->willReturn($versionTime);
+        $localeAware->getLocale()->willReturn('en_US');
+        $datetimePresenter->present($versionTime, Argument::any())->willReturn('01/01/1985 09:41 AM');
+        $version->isPending()->willReturn(false);
+
+        $version->getAuthor()->willReturn('system');
+        $userManager->findUserByUsername('system')->willReturn(null);
+
+        $translator->trans('pim_user.user.system_user')->willReturn('System');
+
+        $userContext->getUserTimezone()->willThrow(\RuntimeException::class);
+
+        $this->normalize($version, 'internal_api')->shouldReturn([
+            'id'          => 12,
+            'author'      => 'System',
+            'resource_id' => '112',
+            'snapshot'    => 'a nice snapshot',
+            'changeset'   => ['text' => 'the changeset'],
+            'context'     => ['locale' => 'en_US', 'channel' => 'mobile'],
+            'version'     => 12,
+            'logged_at'   => '01/01/1985 09:41 AM',
+            'pending'     => false
+        ]);
+    }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

Backport of the system user display fix to 7.0.

On 7.0, when a job runs as the `system` user (e.g. Product Link Rules, catalog imports), the product History tab shows `system - Removed user` instead of `System`. This happens because `VersionNormalizer.normalizeAuthor('system')` tries to find a DB user named `system`, finds none, and falls through to the "Removed user" fallback.

The fix checks for `UserInterface::SYSTEM_USER_NAME` before the fallback, and uses a dedicated `pim_user.user.system_user` translation key.

**Changes:**

- `VersionNormalizer.php` — added `SYSTEM_USER_NAME` check in `normalizeAuthor()`
- `messages.en_US.yml` — added `system_user: System` translation key
- `VersionNormalizerSpec.php` — added `it_normalize_versions_with_system_user` test


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
