### PR TITLE
#20634 [BatchBundle] Unable to send email : Variable "email" does not exist in "@AkeneoBatch/Email/notification.txt.twig"

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
@@ -1,7 +1,6 @@
 {% extends "@PimNotification/Email/notification.txt.twig" %}
 
 {% block emailMessage %}
-    Dear {{ email }},
     {% if jobExecution.status.unsuccessful %}
         Akeneo completed your "{{ jobExecution.jobInstance.label }}" job with errors.
     {% else %}


### PR DESCRIPTION
Fixes #20634

**Description (for Contributor and Core Developer)**

Removes the `Dear {{ email }},` greeting from `notification.txt.twig` — the variable `email` was never passed to the template renderer, causing a Twig `RuntimeError` on every batch job completion and preventing any notification email from being sent.

The HTML counterpart (`notification.html.twig`) had this line removed in a2d9ee9 when the notification system was refactored to send one email to all recipients. The plain-text template was missed in that change.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
