### PR TITLE
Fix 500 error when adding a variant product without an identifier (#20486)

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueAxesCombinationSet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueAxesCombinationSet.php
@@ -49,13 +49,23 @@ class UniqueAxesCombinationSet
      */
     public function addCombination(EntityWithFamilyVariantInterface $entity, string $axisValueCombination): void
     {
+        $identifier = $entity->getIdentifier();
+
+        // A product saved without an identifier (e.g. a variant product without an SKU)
+        // cannot take part in the uniqueness check yet. Skip it so the "identifier is
+        // required" validation can run instead of triggering a 500 error (issue #20486).
+        if (null === $identifier) {
+            return;
+        }
+
+        $loweredIdentifier = \mb_strtolower($identifier);
         $familyVariantCode = $entity->getFamilyVariant()->getCode();
         $parentCode = $entity->getParent()->getCode();
         $loweredAxisValueCombination = \mb_strtolower($axisValueCombination);
 
         if (isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination])) {
             $cachedIdentifier = $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination];
-            if ($cachedIdentifier !== \mb_strtolower($entity->getIdentifier())) {
+            if ($cachedIdentifier !== $loweredIdentifier) {
                 if ($entity instanceof ProductInterface) {
                     throw new AlreadyExistingAxisValueCombinationException(
                         $cachedIdentifier,
@@ -87,7 +97,7 @@ class UniqueAxesCombinationSet
         }
 
         if (!isset($this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination])) {
-            $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination] = \mb_strtolower($entity->getIdentifier());
+            $this->uniqueAxesCombination[$familyVariantCode][$parentCode][$loweredAxisValueCombination] = $loweredIdentifier;
         }
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/UniqueAxesCombinationSetSpec.php
@@ -135,4 +135,23 @@ class UniqueAxesCombinationSetSpec extends ObjectBehavior
             ->shouldThrow($exception)
             ->during('addCombination', [$invalidVariantProduct, '[A_color]']);
     }
+
+    function it_adds_a_combination_for_a_variant_product_without_an_identifier()
+    {
+        $familyVariant = new FamilyVariant();
+        $familyVariant->setCode('family_variant');
+
+        $productModel = new ProductModel();
+        $productModel->setCode('root_product_model');
+        $productModel->setFamilyVariant($familyVariant);
+
+        // A variant product saved without an SKU has a null identifier. It must not
+        // raise a TypeError on \mb_strtolower() so the "identifier is required"
+        // validation can run instead of a 500 error (issue #20486).
+        $variantProductWithoutIdentifier = new Product();
+        $variantProductWithoutIdentifier->setFamilyVariant($familyVariant);
+        $variantProductWithoutIdentifier->setParent($productModel);
+
+        $this->addCombination($variantProductWithoutIdentifier, '[a_color]');
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix #20486

Creating a variant product without an SKU returns a **500 Internal Server Error** instead of the expected "identifier is required" validation message.

Root cause: `UniqueAxesCombinationSet::addCombination()` passes the entity identifier directly to `\mb_strtolower()`. A variant product saved without an SKU has a `null` identifier (`AbstractProduct::$identifier` is `?string` and defaults to `null`), so PHP 8.1 raises:

```
TypeError: mb_strtolower(): Argument #1 ($string) must be of type string, null given
  at src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueAxesCombinationSet.php:90
```

The crash short-circuits the request before the regular "identifier is required" validation can run.

Fix: an entity without an identifier cannot take part in the axis-combination uniqueness check yet, so `addCombination()` now returns early when the identifier is `null`. The regular "identifier is required" validation then surfaces instead of a 500, and we avoid emitting a spurious `AlreadyExistingAxisValueCombinationException` for an incomplete product. `ProductModel::getIdentifier()` returns the code (never `null` once set), so product-model uniqueness is unaffected.

**Test verification (RED -> GREEN)**

A new PHPSpec example (`it_adds_a_combination_for_a_variant_product_without_an_identifier`) reproduces the bug with a variant product that has no identifier.

RED — production code reverted to the `7.0` baseline:
```
139  ! adds a combination for a variant product without an identifier
       exception [err:TypeError("mb_strtolower(): Argument #1 ($string) must be of type string, null given")] has been thrown.
5 examples (4 passed, 1 broken)
```

GREEN — with the fix:
```
139  ✔ adds a combination for a variant product without an identifier
5 examples (5 passed)
```

The 4 pre-existing examples pass in both runs — no regression.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
