### PR TITLE
Fix Error 500 on create group page (#20401)

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
@@ -18,7 +18,13 @@
     }
     %}
 {% else %}
-    {% set breadcrumbs = title %}
+    {% set breadcrumbs = {
+        'entity':      form.vars.value,
+        'indexPath':   '#%s'|format(path('pim_user_group_index')),
+        'indexLabel': 'Groups'|trans,
+        'entityTitle': title
+    }
+    %}
 {% endif %}
 
 {% block navButtons %}

--- a/tests/back/UserManagement/Integration/Bundle/CreateGroupPageIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/CreateGroupPageIntegration.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\UserManagement\Integration\Bundle;
+
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CreateGroupPageIntegration extends ControllerIntegrationTestCase
+{
+    public function test_it_renders_the_create_group_page_without_error(): void
+    {
+        $this->logIn('admin');
+
+        $response = $this->callRoute('pim_user_group_create');
+
+        $this->assertStatusCode($response, Response::HTTP_OK);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/tests/back/UserManagement/Integration/Bundle/CreateGroupPageIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/CreateGroupPageIntegration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace AkeneoTest\UserManagement\Integration\Bundle;
 
 use Akeneo\Test\Integration\Configuration;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
 final class CreateGroupPageIntegration extends ControllerIntegrationTestCase
@@ -17,6 +16,7 @@ final class CreateGroupPageIntegration extends ControllerIntegrationTestCase
         $response = $this->callRoute('pim_user_group_create');
 
         $this->assertStatusCode($response, Response::HTTP_OK);
+        $this->assertStringContainsString('href="#/user/group/"', $response->getContent());
     }
 
     protected function getConfiguration(): Configuration


### PR DESCRIPTION
Fixes #20401

## Problem

Opening the "Create Group" page throws `Error 500, Impossible to access an attribute ("indexPath") on a string variable ("New Group")`.

In `src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig`, the `else` branch (new group / no `entityId`) sets:

```twig
{% set breadcrumbs = title %}
```

`title` is a plain string. The parent template `@PimUI/actions/update.html.twig` unconditionally reads `breadcrumbs.indexPath`, `breadcrumbs.indexLabel` and `breadcrumbs.entityTitle` in its `breadcrumbs` block, which fails on a string when Twig strict variables are enabled.

## Fix

Build the same hash shape used in the existing-group (`entityId`) branch, using the page title as `entityTitle`:

```twig
{% else %}
    {% set breadcrumbs = {
        'entity':      form.vars.value,
        'indexPath':   '#%s'|format(path('pim_user_group_index')),
        'indexLabel': 'Groups'|trans,
        'entityTitle': title
    }
    %}
{% endif %}
```

## Test

Added `tests/back/UserManagement/Integration/Bundle/CreateGroupPageIntegration.php`, an integration test (following the existing pattern in that directory, e.g. `GetUserGroupIntegration.php`) that logs in as `admin` and asserts a `200` response from the `pim_user_group_create` route, which renders the template that previously threw a 500.

**Disclosure:** PHP is not available in the environment used to write this patch, so this test was written per the repo's existing integration-test conventions but has not actually been executed. Please run it (and the existing UserManagement integration suite) in CI/CD before merging.

## CLA

Signed previously on prior merged contributions from this account.