### PR TITLE
Fix null loggedAt when no structure version history record exists

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -1,5 +1,9 @@
 # 7.0.x
 
+## Bug fixes
+
+- #20332: Fix potential type error when fetching the structure version last update row returns null
+
 # 7.0.84 (2025-12-31)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
@@ -44,7 +44,7 @@ SQL;
         );
 
         $row = $stmt->fetchAssociative();
-        $loggedAt = false !== $row ? $row['last_update'] : null;
+        $loggedAt = \is_array($row) ? ($row['last_update'] ?? null) : null;
 
         if (null === $loggedAt) {
             return 0;

--- a/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
@@ -43,7 +43,8 @@ SQL;
             ['resource_names' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         );
 
-        $loggedAt = $stmt->fetchAssociative()['last_update'];
+        $row = $stmt->fetchAssociative();
+        $loggedAt = false !== $row ? $row['last_update'] : null;
 
         if (null === $loggedAt) {
             return 0;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/Provider/StructureVersionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/Provider/StructureVersionSpec.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\StructureVersion\Provider;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Statement;
+use Doctrine\DBAL\Result;
 use Doctrine\Persistence\ManagerRegistry;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -18,7 +18,7 @@ class StructureVersionSpec extends ObjectBehavior
         $this->beConstructedWith($registry);
     }
 
-    function it_returns_zero_when_there_is_no_version_history_record(Connection $connection, Statement $statement)
+    function it_returns_zero_when_there_is_no_version_history_record(Connection $connection, Result $statement)
     {
         $connection->executeQuery(Argument::cetera())->willReturn($statement);
         $statement->fetchAssociative()->willReturn(false);
@@ -26,9 +26,17 @@ class StructureVersionSpec extends ObjectBehavior
         $this->getStructureVersion()->shouldReturn(0);
     }
 
+    function it_returns_zero_when_fetch_associative_returns_null(Connection $connection, Result $statement)
+    {
+        $connection->executeQuery(Argument::cetera())->willReturn($statement);
+        $statement->fetchAssociative()->willReturn(null);
+
+        $this->getStructureVersion()->shouldReturn(0);
+    }
+
     function it_returns_the_timestamp_of_the_last_update_when_a_version_history_record_exists(
         Connection $connection,
-        Statement $statement
+        Result $statement
     ) {
         $connection->executeQuery(Argument::cetera())->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['last_update' => '2021-01-01 00:00:00']);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/Provider/StructureVersionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/Provider/StructureVersionSpec.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\StructureVersion\Provider;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Statement;
+use Doctrine\Persistence\ManagerRegistry;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class StructureVersionSpec extends ObjectBehavior
+{
+    function let(ManagerRegistry $registry, Connection $connection)
+    {
+        $registry->getConnection()->willReturn($connection);
+        $this->beConstructedWith($registry);
+    }
+
+    function it_returns_zero_when_there_is_no_version_history_record(Connection $connection, Statement $statement)
+    {
+        $connection->executeQuery(Argument::cetera())->willReturn($statement);
+        $statement->fetchAssociative()->willReturn(false);
+
+        $this->getStructureVersion()->shouldReturn(0);
+    }
+
+    function it_returns_the_timestamp_of_the_last_update_when_a_version_history_record_exists(
+        Connection $connection,
+        Statement $statement
+    ) {
+        $connection->executeQuery(Argument::cetera())->willReturn($statement);
+        $statement->fetchAssociative()->willReturn(['last_update' => '2021-01-01 00:00:00']);
+        $connection->convertToPHPValue('2021-01-01 00:00:00', 'datetime')
+            ->willReturn(new \DateTime('2021-01-01 00:00:00'));
+
+        $this->getStructureVersion()->shouldReturn((new \DateTime('2021-01-01 00:00:00'))->getTimestamp());
+    }
+}


### PR DESCRIPTION
Fixes #20332

## Problem
`StructureVersion::getStructureVersion()` calls `$stmt->fetchAssociative()['last_update']` directly. `Statement::fetchAssociative()` returns `false` (not an empty array) when no row exists, e.g. on older/imported projects with no `akeneo_structure_version_last_update` rows for the given resource names. Indexing into a `bool` triggers `Warning: Trying to access array offset on value of type bool`, which Symfony's error handler can turn into a fatal error depending on error-reporting configuration.

## Fix
Fetch the row into a variable first and only index into it when it is not `false`, falling back to `null` (which the method already turns into `0`) otherwise.

## Test plan
- Added a phpspec spec (`StructureVersionSpec`) covering:
  - no version history record exists (`fetchAssociative()` returns `false`) -> returns `0`
  - a version history record exists -> returns the expected timestamp
- Could not run `phpspec` locally (no PHP runtime available in this environment); please run `vendor/bin/phpspec run tests/back/Pim/Enrichment/Specification/Bundle/StructureVersion/Provider/StructureVersionSpec.php` in CI/dev to confirm.
