### PR TITLE
Enable Twig strict_variables in the test environment

### DIFF
--- a/config/packages/test/twig.yml
+++ b/config/packages/test/twig.yml
@@ -1,0 +1,2 @@
+twig:
+    strict_variables: true

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
@@ -1,7 +1,6 @@
 {% extends "@PimNotification/Email/notification.txt.twig" %}
 
 {% block emailMessage %}
-    Dear {{ email }},
     {% if jobExecution.status.unsuccessful %}
         Akeneo completed your "{{ jobExecution.jobInstance.label }}" job with errors.
     {% else %}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
[Twig configuration](https://github.com/akeneo/pim-community-dev/blob/main/config/packages/twig.yml#L3) defaults strict_variables to %kernel.debug%, and the integration test kernel boots with debug disabled, so tests ran with production protection: a template reading an attribute on a missing or wrongly typed variable resolved it to null instead of failing.

That hid a real bug (#20401) in the test environment. Reading an attribute on a string raises in Twig only when strict_variables is on, so the create group page was a hard 500 for anyone running with debug on (like in dev mode), while a controller test asserting a 200 stayed green and production silently served a degraded breadcrumb.

This mirrors the Symfony Flex recipe, which ships strict_variables: true in config/packages/test/. Development keeps its strictness and production keeps its protection; only the test kernel changes.
